### PR TITLE
feat: add `EthereumHardforks` trait implementation for use outside of reth

### DIFF
--- a/crates/hardforks/src/forkcondition.rs
+++ b/crates/hardforks/src/forkcondition.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::{BlockNumber, U256};
 
 /// The condition at which a fork is activated.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ForkCondition {
     /// The fork is activated after a certain block.


### PR DESCRIPTION
We need this in some tests for alloy-evm and eventually for block executor exposed for consumers without access to reth's implementations.

Also derived `Ord` for `ForkCondition`. The current impl results in block -> ttd -> timestamp ordering which makes sense in general imo