### PR TITLE
feat: add `OpChainHardforks`

### DIFF
--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -186,7 +186,7 @@ impl OpChainHardforks {
 
     /// Creates a new [`OpChainHardforks`] with Base mainnet configuration.
     pub fn base_mainnet() -> Self {
-        Self::new(OpHardfork::base_mainnet(), Some(0))
+        Self::new(OpHardfork::base_mainnet(), None)
     }
 
     /// Creates a new [`OpChainHardforks`] with Base Sepolia configuration.

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -201,7 +201,7 @@ impl EthereumHardforks for OpChainHardforks {
             // We assume that OP chains were launched with all forks before Berlin activated.
             ForkCondition::Block(0)
         } else if fork == EthereumHardfork::Berlin {
-            // Handle special OP mainnet case of Bedrock activation.
+            // Handle special OP mainnet case of Berlin activation.
             // If `berlin_block` is not set, assume it was enabled at genesis.
             if let Some(berlin_block) = self.berlin_block {
                 ForkCondition::Block(berlin_block)

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -198,20 +198,27 @@ impl OpChainHardforks {
 impl EthereumHardforks for OpChainHardforks {
     fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
         if fork < EthereumHardfork::Berlin {
+            // We assume that OP chains were launched with all forks before Berlin activated.
             ForkCondition::Block(0)
         } else if fork == EthereumHardfork::Berlin {
+            // Handle special OP mainnet case of Bedrock activation.
+            // If `berlin_block` is not set, assume it was enabled at genesis.
             if let Some(berlin_block) = self.berlin_block {
                 ForkCondition::Block(berlin_block)
             } else {
                 ForkCondition::Block(0)
             }
         } else if fork <= EthereumHardfork::Paris {
+            // Bedrock activates all hardforks up to Paris.
             self.op_fork_activation(OpHardfork::Bedrock)
         } else if fork <= EthereumHardfork::Shanghai {
+            // Canyon activates Shanghai hardfork.
             self.op_fork_activation(OpHardfork::Canyon)
         } else if fork <= EthereumHardfork::Cancun {
+            // Ecotone activates Cancun hardfork.
             self.op_fork_activation(OpHardfork::Ecotone)
         } else if fork <= EthereumHardfork::Prague {
+            // Isthmus activates Prague hardfork.
             self.op_fork_activation(OpHardfork::Isthmus)
         } else {
             ForkCondition::Never

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -42,54 +42,54 @@ hardfork!(
 
 impl OpHardfork {
     /// Optimism mainnet list of hardforks.
-    pub fn op_mainnet() -> [(Self, ForkCondition); 7] {
+    pub const fn op_mainnet() -> [(Self, ForkCondition); 7] {
         [
-            (OpHardfork::Bedrock, ForkCondition::Block(105235063)),
-            (OpHardfork::Regolith, ForkCondition::Timestamp(0)),
-            (OpHardfork::Canyon, ForkCondition::Timestamp(1704992401)),
-            (OpHardfork::Ecotone, ForkCondition::Timestamp(1710374401)),
-            (OpHardfork::Fjord, ForkCondition::Timestamp(1720627201)),
-            (OpHardfork::Granite, ForkCondition::Timestamp(1726070401)),
-            (OpHardfork::Holocene, ForkCondition::Timestamp(1736445601)),
+            (Self::Bedrock, ForkCondition::Block(105235063)),
+            (Self::Regolith, ForkCondition::Timestamp(0)),
+            (Self::Canyon, ForkCondition::Timestamp(1704992401)),
+            (Self::Ecotone, ForkCondition::Timestamp(1710374401)),
+            (Self::Fjord, ForkCondition::Timestamp(1720627201)),
+            (Self::Granite, ForkCondition::Timestamp(1726070401)),
+            (Self::Holocene, ForkCondition::Timestamp(1736445601)),
         ]
     }
 
     /// Optimism Sepolia list of hardforks.
-    pub fn op_sepolia() -> [(Self, ForkCondition); 7] {
+    pub const fn op_sepolia() -> [(Self, ForkCondition); 7] {
         [
-            (OpHardfork::Bedrock, ForkCondition::Block(0)),
-            (OpHardfork::Regolith, ForkCondition::Timestamp(0)),
-            (OpHardfork::Canyon, ForkCondition::Timestamp(1699981200)),
-            (OpHardfork::Ecotone, ForkCondition::Timestamp(1708534800)),
-            (OpHardfork::Fjord, ForkCondition::Timestamp(1716998400)),
-            (OpHardfork::Granite, ForkCondition::Timestamp(1723478400)),
-            (OpHardfork::Holocene, ForkCondition::Timestamp(1732633200)),
+            (Self::Bedrock, ForkCondition::Block(0)),
+            (Self::Regolith, ForkCondition::Timestamp(0)),
+            (Self::Canyon, ForkCondition::Timestamp(1699981200)),
+            (Self::Ecotone, ForkCondition::Timestamp(1708534800)),
+            (Self::Fjord, ForkCondition::Timestamp(1716998400)),
+            (Self::Granite, ForkCondition::Timestamp(1723478400)),
+            (Self::Holocene, ForkCondition::Timestamp(1732633200)),
         ]
     }
 
     /// Base mainnet list of hardforks.
-    pub fn base_mainnet() -> [(Self, ForkCondition); 7] {
+    pub const fn base_mainnet() -> [(Self, ForkCondition); 7] {
         [
-            (OpHardfork::Bedrock, ForkCondition::Block(0)),
-            (OpHardfork::Regolith, ForkCondition::Timestamp(0)),
-            (OpHardfork::Canyon, ForkCondition::Timestamp(1704992401)),
-            (OpHardfork::Ecotone, ForkCondition::Timestamp(1710374401)),
-            (OpHardfork::Fjord, ForkCondition::Timestamp(1720627201)),
-            (OpHardfork::Granite, ForkCondition::Timestamp(1726070401)),
-            (OpHardfork::Holocene, ForkCondition::Timestamp(1736445601)),
+            (Self::Bedrock, ForkCondition::Block(0)),
+            (Self::Regolith, ForkCondition::Timestamp(0)),
+            (Self::Canyon, ForkCondition::Timestamp(1704992401)),
+            (Self::Ecotone, ForkCondition::Timestamp(1710374401)),
+            (Self::Fjord, ForkCondition::Timestamp(1720627201)),
+            (Self::Granite, ForkCondition::Timestamp(1726070401)),
+            (Self::Holocene, ForkCondition::Timestamp(1736445601)),
         ]
     }
 
     /// Base Sepolia list of hardforks.
-    pub fn base_sepolia() -> [(Self, ForkCondition); 7] {
+    pub const fn base_sepolia() -> [(Self, ForkCondition); 7] {
         [
-            (OpHardfork::Bedrock, ForkCondition::Block(0)),
-            (OpHardfork::Regolith, ForkCondition::Timestamp(0)),
-            (OpHardfork::Canyon, ForkCondition::Timestamp(1699981200)),
-            (OpHardfork::Ecotone, ForkCondition::Timestamp(1708534800)),
-            (OpHardfork::Fjord, ForkCondition::Timestamp(1716998400)),
-            (OpHardfork::Granite, ForkCondition::Timestamp(1723478400)),
-            (OpHardfork::Holocene, ForkCondition::Timestamp(1732633200)),
+            (Self::Bedrock, ForkCondition::Block(0)),
+            (Self::Regolith, ForkCondition::Timestamp(0)),
+            (Self::Canyon, ForkCondition::Timestamp(1699981200)),
+            (Self::Ecotone, ForkCondition::Timestamp(1708534800)),
+            (Self::Fjord, ForkCondition::Timestamp(1716998400)),
+            (Self::Granite, ForkCondition::Timestamp(1723478400)),
+            (Self::Holocene, ForkCondition::Timestamp(1732633200)),
         ]
     }
 }
@@ -203,11 +203,7 @@ impl EthereumHardforks for OpChainHardforks {
         } else if fork == EthereumHardfork::Berlin {
             // Handle special OP mainnet case of Berlin activation.
             // If `berlin_block` is not set, assume it was enabled at genesis.
-            if let Some(berlin_block) = self.berlin_block {
-                ForkCondition::Block(berlin_block)
-            } else {
-                ForkCondition::Block(0)
-            }
+            self.berlin_block.map_or(ForkCondition::Block(0), ForkCondition::Block)
         } else if fork <= EthereumHardfork::Paris {
             // Bedrock activates all hardforks up to Paris.
             self.op_fork_activation(OpHardfork::Bedrock)

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -153,7 +153,7 @@ pub trait OpHardforks: EthereumHardforks {
 }
 
 /// A type allowing to configure activation [`ForkCondition`]s for a given list of
-/// [`EthereumHardfork`]s.
+/// [`OpHardfork`]s.
 #[derive(Debug, Clone)]
 pub struct OpChainHardforks {
     /// Special case for OP mainnet which had Bedrock activated separately without an associated

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,10 @@
 [advisories]
 version = 2
 yanked = "warn"
-ignore = []
+ignore = [
+    # https://rustsec.org/advisories/RUSTSEC-2024-0436
+    "RUSTSEC-2024-0436",
+]
 
 [bans]
 multiple-versions = "warn"


### PR DESCRIPTION
Adds a reference implementation of `OpHardforks` which can be used outside of reth. It encapsulates mapping from op to ethereum spec and covers special case of berlin activation on OP mainnet

This struct has enough context for building an fork id for OP chains so eventually we can consider integrating this directly into reth to get rid of `dyn Hardfork` usage 