### PR TITLE
fix(op-mainnet): public export op hardfork constants

### DIFF
--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -11,8 +11,9 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 use alloy_hardforks::{hardfork, EthereumHardfork, EthereumHardforks, ForkCondition};
-mod optimism;
-use optimism::mainnet::*;
+pub mod optimism;
+pub use optimism::*;
+
 hardfork!(
     /// The name of an optimism hardfork.
     ///

--- a/crates/op-hardforks/src/optimism/mainnet.rs
+++ b/crates/op-hardforks/src/optimism/mainnet.rs
@@ -1,12 +1,14 @@
+//! Optimism Mainnet hardfork starting points
+
 /// Bedrock hardfork activation block
-pub(crate) const OP_MAINNET_BEDROCK_BLOCK: u64 = 105_235_063;
+pub const OP_MAINNET_BEDROCK_BLOCK: u64 = 105_235_063;
 /// Canyon hardfork activation timestamp
-pub(crate) const OP_MAINNET_CANYON_TIMESTAMP: u64 = 1_704_992_401;
+pub const OP_MAINNET_CANYON_TIMESTAMP: u64 = 1_704_992_401;
 /// Ecotone hardfork activation timestamp
-pub(crate) const OP_MAINNET_ECOTONE_TIMESTAMP: u64 = 1_710_374_401;
+pub const OP_MAINNET_ECOTONE_TIMESTAMP: u64 = 1_710_374_401;
 /// Fjord hardfork activation timestamp
-pub(crate) const OP_MAINNET_FJORD_TIMESTAMP: u64 = 1_720_627_201;
+pub const OP_MAINNET_FJORD_TIMESTAMP: u64 = 1_720_627_201;
 /// Granite hardfork activation timestamp
-pub(crate) const OP_MAINNET_GRANITE_TIMESTAMP: u64 = 1_726_070_401;
+pub const OP_MAINNET_GRANITE_TIMESTAMP: u64 = 1_726_070_401;
 /// Holocene hardfork activation timestamp
-pub(crate) const OP_MAINNET_HOLOCENE_TIMESTAMP: u64 = 1_736_445_601;
+pub const OP_MAINNET_HOLOCENE_TIMESTAMP: u64 = 1_736_445_601;

--- a/crates/op-hardforks/src/optimism/mod.rs
+++ b/crates/op-hardforks/src/optimism/mod.rs
@@ -1,1 +1,4 @@
-pub(crate) mod mainnet;
+//! Optimism hardfork starting points
+
+pub mod mainnet;
+pub use mainnet::*;


### PR DESCRIPTION
Ref https://github.com/alloy-rs/hardforks/issues/12

Exports op mainnet constants from crate root.