### PR TITLE
chore(op): Remove redundant berlin block variable from `OpChainHardforks`

### DIFF
--- a/crates/hardforks/src/forkcondition.rs
+++ b/crates/hardforks/src/forkcondition.rs
@@ -34,7 +34,7 @@ pub enum ForkCondition {
 impl ForkCondition {
     /// Block number 0, equivalent to activation at genesis.
     pub const ZERO_BLOCK: Self = Self::Block(0);
-    
+
     /// Timestamp 0, equivalent to activation at genesis.
     pub const ZERO_TIMESTAMP: Self = Self::Timestamp(0);
 

--- a/crates/hardforks/src/forkcondition.rs
+++ b/crates/hardforks/src/forkcondition.rs
@@ -32,6 +32,12 @@ pub enum ForkCondition {
 }
 
 impl ForkCondition {
+    /// Block number 0, equivalent to activation at genesis.
+    pub const ZERO_BLOCK: Self = Self::Block(0);
+    
+    /// Timestamp 0, equivalent to activation at genesis.
+    pub const ZERO_TIMESTAMP: Self = Self::Timestamp(0);
+
     /// Returns true if the fork condition is timestamp based.
     pub const fn is_timestamp(&self) -> bool {
         matches!(self, Self::Timestamp(_))

--- a/crates/op-hardforks/src/base/mainnet.rs
+++ b/crates/op-hardforks/src/base/mainnet.rs
@@ -2,6 +2,10 @@
 
 use crate::optimism::mainnet::*;
 
+/// Bedrock base hardfork activation block
+pub const BASE_MAINNET_BEDROCK_BLOCK: u64 = 0;
+/// Regolith base hardfork activation timestamp
+pub const BASE_MAINNET_REGOLITH_TIMESTAMP: u64 = OP_MAINNET_REGOLITH_TIMESTAMP;
 /// Canyon base hardfork activation timestamp
 pub const BASE_MAINNET_CANYON_TIMESTAMP: u64 = OP_MAINNET_CANYON_TIMESTAMP;
 /// Ecotone base hardfork activation timestamp

--- a/crates/op-hardforks/src/base/sepolia.rs
+++ b/crates/op-hardforks/src/base/sepolia.rs
@@ -2,6 +2,10 @@
 
 use crate::optimism::sepolia::*;
 
+/// Bedrock base sepolia hardfork activation block
+pub const BASE_SEPOLIA_BEDROCK_BLOCK: u64 = OP_SEPOLIA_BEDROCK_BLOCK;
+/// Regolith base sepolia hardfork activation timestamp
+pub const BASE_SEPOLIA_REGOLITH_TIMESTAMP: u64 = OP_SEPOLIA_REGOLITH_TIMESTAMP;
 /// Canyon base sepolia hardfork activation timestamp
 pub const BASE_SEPOLIA_CANYON_TIMESTAMP: u64 = OP_SEPOLIA_CANYON_TIMESTAMP;
 /// Ecotone base sepolia hardfork activation timestamp

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -285,7 +285,7 @@ impl Index<EthereumHardfork> for OpChainHardforks {
             Shanghai => &self[Canyon],
             Cancun => &self[Ecotone],
             Prague => &self[Isthmus],
-            Osaka => &ForkCondition::Never,
+            Osaka => panic!("index out of bounds"),
         }
     }
 }

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -18,7 +18,7 @@ pub use optimism::*;
 hardfork!(
     /// The name of an optimism hardfork.
     ///
-    /// When building a list of hardforks for a chain, it's still expected to mix with
+    /// When building a list of hardforks for a chain, it's still expected to zip with
     /// [`EthereumHardfork`].
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     OpHardfork {

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -191,7 +191,8 @@ pub struct OpChainHardforks {
 }
 
 impl OpChainHardforks {
-    /// Creates a new [`OpChainHardforks`] with the given list of forks.
+    /// Creates a new [`OpChainHardforks`] with the given list of forks. The input list is sorted
+    /// w.r.t. the hardcoded canonicity of [`OpHardfork`]s.
     pub fn new(forks: impl IntoIterator<Item = (OpHardfork, ForkCondition)>) -> Self {
         let mut forks = forks.into_iter().collect::<Vec<_>>();
         forks.sort();

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -279,11 +279,11 @@ impl Index<EthereumHardfork> for OpChainHardforks {
 
         match hf {
             Frontier | Homestead | Dao | Tangerine | SpuriousDragon | Byzantium
-            | Constantinople | Petersburg | Istanbul | MuirGlacier => &ForkCondition::Block(0),
+            | Constantinople | Petersburg | Istanbul | MuirGlacier => &ForkCondition::ZERO_BLOCK,
             Berlin if self[Bedrock] == ForkCondition::Block(OP_MAINNET_BEDROCK_BLOCK) => {
                 &ForkCondition::Block(OP_MAINNET_BERLIN_BLOCK)
             }
-            Berlin => &ForkCondition::Block(0),
+            Berlin => &ForkCondition::ZERO_BLOCK,
             London | ArrowGlacier | GrayGlacier | Paris => &self[Bedrock],
             Shanghai => &self[Canyon],
             Cancun => &self[Ecotone],

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -217,6 +217,11 @@ impl OpChainHardforks {
     pub fn base_sepolia() -> Self {
         Self::new(OpHardfork::base_sepolia())
     }
+
+    /// Returns true if this is an OP mainnet instance.
+    pub fn is_op_mainnet(&self) -> bool {
+        self[OpHardfork::Bedrock] == ForkCondition::Block(OP_MAINNET_BEDROCK_BLOCK)
+    }
 }
 
 impl EthereumHardforks for OpChainHardforks {
@@ -280,9 +285,7 @@ impl Index<EthereumHardfork> for OpChainHardforks {
         match hf {
             Frontier | Homestead | Dao | Tangerine | SpuriousDragon | Byzantium
             | Constantinople | Petersburg | Istanbul | MuirGlacier => &ForkCondition::ZERO_BLOCK,
-            Berlin if self[Bedrock] == ForkCondition::Block(OP_MAINNET_BEDROCK_BLOCK) => {
-                &ForkCondition::Block(OP_MAINNET_BERLIN_BLOCK)
-            }
+            Berlin if self.is_op_mainnet() => &ForkCondition::Block(OP_MAINNET_BERLIN_BLOCK),
             Berlin => &ForkCondition::ZERO_BLOCK,
             London | ArrowGlacier | GrayGlacier | Paris => &self[Bedrock],
             Shanghai => &self[Canyon],

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -9,9 +9,7 @@
 
 extern crate alloc;
 use alloc::vec::Vec;
-use alloy_hardforks::{
-    hardfork, EthereumHardfork, EthereumHardforks, ForkCondition,
-};
+use alloy_hardforks::{hardfork, EthereumHardfork, EthereumHardforks, ForkCondition};
 use core::ops::Index;
 
 pub mod optimism;
@@ -172,42 +170,36 @@ pub trait OpHardforks: EthereumHardforks {
 /// other way around.
 #[derive(Debug, Clone)]
 pub struct OpChainHardforks {
-    /// Special case for OP mainnet which had Bedrock activated separately without an associated
-    /// [`OpHardfork`].
-    berlin_block: Option<u64>,
     /// Ordered list of OP hardfork activations.
     forks: Vec<(OpHardfork, ForkCondition)>,
 }
 
 impl OpChainHardforks {
     /// Creates a new [`OpChainHardforks`] with the given list of forks.
-    pub fn new(
-        forks: impl IntoIterator<Item = (OpHardfork, ForkCondition)>,
-        berlin_block: Option<u64>,
-    ) -> Self {
+    pub fn new(forks: impl IntoIterator<Item = (OpHardfork, ForkCondition)>) -> Self {
         let mut forks = forks.into_iter().collect::<Vec<_>>();
         forks.sort();
-        Self { forks, berlin_block }
+        Self { forks }
     }
 
     /// Creates a new [`OpChainHardforks`] with OP mainnet configuration.
     pub fn op_mainnet() -> Self {
-        Self::new(OpHardfork::op_mainnet(), Some(3_950_000))
+        Self::new(OpHardfork::op_mainnet())
     }
 
     /// Creates a new [`OpChainHardforks`] with OP Sepolia configuration.
     pub fn op_sepolia() -> Self {
-        Self::new(OpHardfork::op_sepolia(), None)
+        Self::new(OpHardfork::op_sepolia())
     }
 
     /// Creates a new [`OpChainHardforks`] with Base mainnet configuration.
     pub fn base_mainnet() -> Self {
-        Self::new(OpHardfork::base_mainnet(), None)
+        Self::new(OpHardfork::base_mainnet())
     }
 
     /// Creates a new [`OpChainHardforks`] with Base Sepolia configuration.
     pub fn base_sepolia() -> Self {
-        Self::new(OpHardfork::base_sepolia(), None)
+        Self::new(OpHardfork::base_sepolia())
     }
 }
 

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -257,15 +257,15 @@ impl Index<OpHardfork> for OpChainHardforks {
         use OpHardfork::*;
 
         match hf {
-            Bedrock => &self.forks[0].1,
-            Regolith => &self.forks[1].1,
-            Canyon => &self.forks[2].1,
-            Ecotone => &self.forks[3].1,
-            Fjord => &self.forks[4].1,
-            Granite => &self.forks[5].1,
-            Holocene => &self.forks[6].1,
-            Isthmus => &self.forks[7].1,
-            Interop => &self.forks[8].1,
+            Bedrock => &self.forks[Bedrock.idx()].1,
+            Regolith => &self.forks[Regolith.idx()].1,
+            Canyon => &self.forks[Canyon.idx()].1,
+            Ecotone => &self.forks[Ecotone.idx()].1,
+            Fjord => &self.forks[Fjord.idx()].1,
+            Granite => &self.forks[Granite.idx()].1,
+            Holocene => &self.forks[Holocene.idx()].1,
+            Isthmus => &self.forks[Isthmus.idx()].1,
+            Interop => &self.forks[Interop.idx()].1,
         }
     }
 }

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -100,18 +100,7 @@ impl OpHardfork {
 
     /// Returns index of `self` in sorted canonical array.
     pub const fn idx(&self) -> usize {
-        use OpHardfork::*;
-        match self {
-            Bedrock => 0,
-            Regolith => 1,
-            Canyon => 2,
-            Ecotone => 3,
-            Fjord => 4,
-            Granite => 5,
-            Holocene => 6,
-            Isthmus => 7,
-            Interop => 8,
-        }
+        *self as usize
     }
 }
 

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -383,4 +383,75 @@ mod tests {
         );
         assert_eq!(op_sepolia_forks.op_fork_activation(Interop), ForkCondition::Never);
     }
+
+    #[test]
+    fn base_mainnet_fork_conditions() {
+        use OpHardfork::*;
+
+        let base_mainnet_forks = OpChainHardforks::base_mainnet();
+        assert_eq!(base_mainnet_forks[Bedrock], ForkCondition::Block(BASE_MAINNET_BEDROCK_BLOCK));
+        assert_eq!(
+            base_mainnet_forks[Regolith],
+            ForkCondition::Timestamp(BASE_MAINNET_REGOLITH_TIMESTAMP)
+        );
+        assert_eq!(
+            base_mainnet_forks[Canyon],
+            ForkCondition::Timestamp(BASE_MAINNET_CANYON_TIMESTAMP)
+        );
+        assert_eq!(
+            base_mainnet_forks[Ecotone],
+            ForkCondition::Timestamp(BASE_MAINNET_ECOTONE_TIMESTAMP)
+        );
+        assert_eq!(
+            base_mainnet_forks[Fjord],
+            ForkCondition::Timestamp(BASE_MAINNET_FJORD_TIMESTAMP)
+        );
+        assert_eq!(
+            base_mainnet_forks[Granite],
+            ForkCondition::Timestamp(BASE_MAINNET_GRANITE_TIMESTAMP)
+        );
+        assert_eq!(
+            base_mainnet_forks[Holocene],
+            ForkCondition::Timestamp(BASE_MAINNET_HOLOCENE_TIMESTAMP)
+        );
+        assert_eq!(base_mainnet_forks.op_fork_activation(Isthmus), ForkCondition::Never);
+        assert_eq!(base_mainnet_forks.op_fork_activation(Interop), ForkCondition::Never);
+    }
+
+    #[test]
+    fn base_sepolia_fork_conditions() {
+        use OpHardfork::*;
+
+        let base_sepolia_forks = OpChainHardforks::base_sepolia();
+        assert_eq!(base_sepolia_forks[Bedrock], ForkCondition::Block(BASE_SEPOLIA_BEDROCK_BLOCK));
+        assert_eq!(
+            base_sepolia_forks[Regolith],
+            ForkCondition::Timestamp(BASE_SEPOLIA_REGOLITH_TIMESTAMP)
+        );
+        assert_eq!(
+            base_sepolia_forks[Canyon],
+            ForkCondition::Timestamp(BASE_SEPOLIA_CANYON_TIMESTAMP)
+        );
+        assert_eq!(
+            base_sepolia_forks[Ecotone],
+            ForkCondition::Timestamp(BASE_SEPOLIA_ECOTONE_TIMESTAMP)
+        );
+        assert_eq!(
+            base_sepolia_forks[Fjord],
+            ForkCondition::Timestamp(BASE_SEPOLIA_FJORD_TIMESTAMP)
+        );
+        assert_eq!(
+            base_sepolia_forks[Granite],
+            ForkCondition::Timestamp(BASE_SEPOLIA_GRANITE_TIMESTAMP)
+        );
+        assert_eq!(
+            base_sepolia_forks[Holocene],
+            ForkCondition::Timestamp(BASE_SEPOLIA_HOLOCENE_TIMESTAMP)
+        );
+        assert_eq!(
+            base_sepolia_forks[Isthmus],
+            ForkCondition::Timestamp(BASE_SEPOLIA_ISTHMUS_TIMESTAMP)
+        );
+        assert_eq!(base_sepolia_forks.op_fork_activation(Interop), ForkCondition::Never);
+    }
 }

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -235,6 +235,15 @@ pub trait OpHardforks: EthereumHardforks {
 
 /// A type allowing to configure activation [`ForkCondition`]s for a given list of
 /// [`OpHardfork`]s.
+///
+/// Zips together [`EthereumHardfork`]s and [`OpHardfork`]s. Optimism forks, at least, whenever
+/// Ethereum hard forks. When Ethereum hard forks, a new [`OpHardfork`] piggybacks on top of
+/// the new [`EthereumHardfork`] to include (or to noop) the L1 changes on L2.
+///
+/// Optimism can also hard fork independently of Ethereum. The relation between Ethereum and
+/// Optimism hard forks is described by predicate [`EthereumHardfork`] `=>` [`OpHardfork`], since
+/// an OP chain can have undergo an [`OpHardfork`] without an [`EthereumHardfork`], but not the
+/// other way around.
 #[derive(Debug, Clone)]
 pub struct OpChainHardforks {
     /// Special case for OP mainnet which had Bedrock activated separately without an associated

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -176,9 +176,9 @@ pub trait OpHardforks: EthereumHardforks {
 /// A type allowing to configure activation [`ForkCondition`]s for a given list of
 /// [`OpHardfork`]s.
 ///
-/// Zips together [`EthereumHardfork`]s and [`OpHardfork`]s. Optimism forks, at least, whenever
-/// Ethereum hard forks. When Ethereum hard forks, a new [`OpHardfork`] piggybacks on top of
-/// the new [`EthereumHardfork`] to include (or to noop) the L1 changes on L2.
+/// Zips together [`EthereumHardfork`]s and [`OpHardfork`]s. Optimism hard forks, at least,
+/// whenever Ethereum hard forks. When Ethereum hard forks, a new [`OpHardfork`] piggybacks on top
+/// of the new [`EthereumHardfork`] to include (or to noop) the L1 changes on L2.
 ///
 /// Optimism can also hard fork independently of Ethereum. The relation between Ethereum and
 /// Optimism hard forks is described by predicate [`EthereumHardfork`] `=>` [`OpHardfork`], since

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -97,6 +97,22 @@ impl OpHardfork {
             (Self::Isthmus, ForkCondition::Timestamp(1744905600)),
         ]
     }
+
+    /// Returns index of `self` in sorted canonical array.
+    pub const fn idx(&self) -> usize {
+        use OpHardfork::*;
+        match self {
+            Bedrock => 0,
+            Regolith => 1,
+            Canyon => 2,
+            Ecotone => 3,
+            Fjord => 4,
+            Granite => 5,
+            Holocene => 6,
+            Isthmus => 7,
+            Interop => 8,
+        }
+    }
 }
 
 /// Extends [`EthereumHardforks`] with optimism helper methods.
@@ -205,7 +221,8 @@ impl OpChainHardforks {
 
 impl EthereumHardforks for OpChainHardforks {
     fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
-        use EthereumHardfork::*;
+        use EthereumHardfork::{Cancun, Osaka, Prague, Shanghai};
+        use OpHardfork::{Canyon, Ecotone, Isthmus};
 
         if self.forks.is_empty() {
             return ForkCondition::Never;
@@ -214,9 +231,9 @@ impl EthereumHardforks for OpChainHardforks {
         let forks_len = self.forks.len();
         // check index out of bounds
         match fork {
-            Shanghai if forks_len < 3 => ForkCondition::Never,
-            Cancun if forks_len < 4 => ForkCondition::Never,
-            Prague if forks_len < 8 => ForkCondition::Never,
+            Shanghai if forks_len <= Canyon.idx() => ForkCondition::Never,
+            Cancun if forks_len <= Ecotone.idx() => ForkCondition::Never,
+            Prague if forks_len <= Isthmus.idx() => ForkCondition::Never,
             Osaka => ForkCondition::Never,
             _ => self[fork],
         }
@@ -225,25 +242,11 @@ impl EthereumHardforks for OpChainHardforks {
 
 impl OpHardforks for OpChainHardforks {
     fn op_fork_activation(&self, fork: OpHardfork) -> ForkCondition {
-        use OpHardfork::*;
-
-        if self.forks.is_empty() {
+        // check index out of bounds
+        if self.forks.len() <= fork.idx() {
             return ForkCondition::Never;
         }
-
-        let forks_len = self.forks.len();
-        // check index out of bounds
-        match fork {
-            Regolith if forks_len < 2 => ForkCondition::Never,
-            Canyon if forks_len < 3 => ForkCondition::Never,
-            Ecotone if forks_len < 4 => ForkCondition::Never,
-            Fjord if forks_len < 5 => ForkCondition::Never,
-            Granite if forks_len < 6 => ForkCondition::Never,
-            Holocene if forks_len < 7 => ForkCondition::Never,
-            Isthmus if forks_len < 8 => ForkCondition::Never,
-            Interop if forks_len < 9 => ForkCondition::Never,
-            _ => self[fork],
-        }
+        self[fork]
     }
 }
 

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -205,13 +205,45 @@ impl OpChainHardforks {
 
 impl EthereumHardforks for OpChainHardforks {
     fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
-        self[fork]
+        use EthereumHardfork::*;
+
+        if self.forks.is_empty() {
+            return ForkCondition::Never;
+        }
+
+        let forks_len = self.forks.len();
+        // check index out of bounds
+        match fork {
+            Shanghai if forks_len < 3 => ForkCondition::Never,
+            Cancun if forks_len < 4 => ForkCondition::Never,
+            Prague if forks_len < 8 => ForkCondition::Never,
+            Osaka => ForkCondition::Never,
+            _ => self[fork],
+        }
     }
 }
 
 impl OpHardforks for OpChainHardforks {
     fn op_fork_activation(&self, fork: OpHardfork) -> ForkCondition {
-        self[fork]
+        use OpHardfork::*;
+
+        if self.forks.is_empty() {
+            return ForkCondition::Never;
+        }
+
+        let forks_len = self.forks.len();
+        // check index out of bounds
+        match fork {
+            Regolith if forks_len < 2 => ForkCondition::Never,
+            Canyon if forks_len < 3 => ForkCondition::Never,
+            Ecotone if forks_len < 4 => ForkCondition::Never,
+            Fjord if forks_len < 5 => ForkCondition::Never,
+            Granite if forks_len < 6 => ForkCondition::Never,
+            Holocene if forks_len < 7 => ForkCondition::Never,
+            Isthmus if forks_len < 8 => ForkCondition::Never,
+            Interop if forks_len < 9 => ForkCondition::Never,
+            _ => self[fork],
+        }
     }
 }
 

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -9,7 +9,10 @@
 
 extern crate alloc;
 use alloc::vec::Vec;
-use alloy_hardforks::{hardfork, EthereumHardfork, EthereumHardforks, ForkCondition};
+use alloy_hardforks::{
+    hardfork, EthereumHardfork, EthereumHardforks, ForkCondition, RollupHardfork,
+};
+use core::ops::Index;
 
 pub mod optimism;
 pub use optimism::*;
@@ -95,6 +98,80 @@ impl OpHardfork {
             (Self::Holocene, ForkCondition::Timestamp(1732633200)),
             (Self::Isthmus, ForkCondition::Timestamp(1744905600)),
         ]
+    }
+}
+
+impl Index<OpHardfork> for &[(OpHardfork, ForkCondition)] {
+    type Output = ForkCondition;
+
+    fn index(&self, hf: OpHardfork) -> &Self::Output {
+        use OpHardfork::*;
+
+        match hf {
+            Bedrock => self
+                .get(0)
+                .map(|(hf, block)| {
+                    debug_assert!(matches!(hf, Bedrock));
+                    block
+                })
+                .expect("bedrock block"),
+            Regolith => self
+                .get(1)
+                .map(|(hf, time)| {
+                    debug_assert!(matches!(hf, Regolith));
+                    time
+                })
+                .expect("regolith timestamp"),
+            Canyon => self
+                .get(2)
+                .map(|(hf, time)| {
+                    debug_assert!(matches!(hf, Canyon));
+                    time
+                })
+                .expect("canyon timestamp"),
+            Ecotone => self
+                .get(3)
+                .map(|(hf, time)| {
+                    debug_assert!(matches!(hf, Ecotone));
+                    time
+                })
+                .expect("ecotone timestamp"),
+            Fjord => self
+                .get(4)
+                .map(|(hf, time)| {
+                    debug_assert!(matches!(hf, Fjord));
+                    time
+                })
+                .expect("fjord timestamp"),
+            Granite => self
+                .get(5)
+                .map(|(hf, time)| {
+                    debug_assert!(matches!(hf, Granite));
+                    time
+                })
+                .expect("granite timestamp"),
+            Holocene => self
+                .get(6)
+                .map(|(hf, time)| {
+                    debug_assert!(matches!(hf, Holocene));
+                    time
+                })
+                .expect("holocene timestamp"),
+            Isthmus => self
+                .get(7)
+                .map(|(hf, time)| {
+                    debug_assert!(matches!(hf, Isthmus));
+                    time
+                })
+                .expect("isthmus timestamp"),
+            Interop => self
+                .get(8)
+                .map(|(hf, time)| {
+                    debug_assert!(matches!(hf, Interop));
+                    time
+                })
+                .expect("interop timestamp"),
+        }
     }
 }
 
@@ -228,11 +305,7 @@ impl EthereumHardforks for OpChainHardforks {
 
 impl OpHardforks for OpChainHardforks {
     fn op_fork_activation(&self, fork: OpHardfork) -> ForkCondition {
-        let Ok(idx) = self.forks.binary_search_by(|(f, _)| f.cmp(&fork)) else {
-            return ForkCondition::Never;
-        };
-
-        self.forks[idx].1
+        self.forks.as_slice()[fork]
     }
 }
 

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -48,7 +48,7 @@ impl OpHardfork {
     pub const fn op_mainnet() -> [(Self, ForkCondition); 7] {
         [
             (Self::Bedrock, ForkCondition::Block(OP_MAINNET_BEDROCK_BLOCK)),
-            (Self::Regolith, ForkCondition::Timestamp(0)),
+            (Self::Regolith, ForkCondition::Timestamp(OP_MAINNET_REGOLITH_TIMESTAMP)),
             (Self::Canyon, ForkCondition::Timestamp(OP_MAINNET_CANYON_TIMESTAMP)),
             (Self::Ecotone, ForkCondition::Timestamp(OP_MAINNET_ECOTONE_TIMESTAMP)),
             (Self::Fjord, ForkCondition::Timestamp(OP_MAINNET_FJORD_TIMESTAMP)),
@@ -60,8 +60,8 @@ impl OpHardfork {
     /// Optimism Sepolia list of hardforks.
     pub const fn op_sepolia() -> [(Self, ForkCondition); 8] {
         [
-            (Self::Bedrock, ForkCondition::Block(0)),
-            (Self::Regolith, ForkCondition::Timestamp(0)),
+            (Self::Bedrock, ForkCondition::Block(OP_SEPOLIA_BEDROCK_BLOCK)),
+            (Self::Regolith, ForkCondition::Timestamp(OP_SEPOLIA_REGOLITH_TIMESTAMP)),
             (Self::Canyon, ForkCondition::Timestamp(OP_SEPOLIA_CANYON_TIMESTAMP)),
             (Self::Ecotone, ForkCondition::Timestamp(OP_SEPOLIA_ECOTONE_TIMESTAMP)),
             (Self::Fjord, ForkCondition::Timestamp(OP_SEPOLIA_FJORD_TIMESTAMP)),
@@ -320,5 +320,64 @@ mod tests {
     #[test]
     fn check_nonexistent_hardfork_from_str() {
         assert!(OpHardfork::from_str("not a hardfork").is_err());
+    }
+
+    #[test]
+    fn op_mainnet_fork_conditions() {
+        use OpHardfork::*;
+
+        let op_mainnet_forks = OpChainHardforks::op_mainnet();
+        assert_eq!(op_mainnet_forks[Bedrock], ForkCondition::Block(OP_MAINNET_BEDROCK_BLOCK));
+        assert_eq!(
+            op_mainnet_forks[Regolith],
+            ForkCondition::Timestamp(OP_MAINNET_REGOLITH_TIMESTAMP)
+        );
+        assert_eq!(op_mainnet_forks[Canyon], ForkCondition::Timestamp(OP_MAINNET_CANYON_TIMESTAMP));
+        assert_eq!(
+            op_mainnet_forks[Ecotone],
+            ForkCondition::Timestamp(OP_MAINNET_ECOTONE_TIMESTAMP)
+        );
+        assert_eq!(op_mainnet_forks[Fjord], ForkCondition::Timestamp(OP_MAINNET_FJORD_TIMESTAMP));
+        assert_eq!(
+            op_mainnet_forks[Granite],
+            ForkCondition::Timestamp(OP_MAINNET_GRANITE_TIMESTAMP)
+        );
+        assert_eq!(
+            op_mainnet_forks[Holocene],
+            ForkCondition::Timestamp(OP_MAINNET_HOLOCENE_TIMESTAMP)
+        );
+        assert_eq!(op_mainnet_forks.op_fork_activation(Isthmus), ForkCondition::Never);
+        assert_eq!(op_mainnet_forks.op_fork_activation(Interop), ForkCondition::Never);
+    }
+
+    #[test]
+    fn op_sepolia_fork_conditions() {
+        use OpHardfork::*;
+
+        let op_sepolia_forks = OpChainHardforks::op_sepolia();
+        assert_eq!(op_sepolia_forks[Bedrock], ForkCondition::Block(OP_SEPOLIA_BEDROCK_BLOCK));
+        assert_eq!(
+            op_sepolia_forks[Regolith],
+            ForkCondition::Timestamp(OP_SEPOLIA_REGOLITH_TIMESTAMP)
+        );
+        assert_eq!(op_sepolia_forks[Canyon], ForkCondition::Timestamp(OP_SEPOLIA_CANYON_TIMESTAMP));
+        assert_eq!(
+            op_sepolia_forks[Ecotone],
+            ForkCondition::Timestamp(OP_SEPOLIA_ECOTONE_TIMESTAMP)
+        );
+        assert_eq!(op_sepolia_forks[Fjord], ForkCondition::Timestamp(OP_SEPOLIA_FJORD_TIMESTAMP));
+        assert_eq!(
+            op_sepolia_forks[Granite],
+            ForkCondition::Timestamp(OP_SEPOLIA_GRANITE_TIMESTAMP)
+        );
+        assert_eq!(
+            op_sepolia_forks[Holocene],
+            ForkCondition::Timestamp(OP_SEPOLIA_HOLOCENE_TIMESTAMP)
+        );
+        assert_eq!(
+            op_sepolia_forks[Isthmus],
+            ForkCondition::Timestamp(OP_SEPOLIA_ISTHMUS_TIMESTAMP)
+        );
+        assert_eq!(op_sepolia_forks.op_fork_activation(Interop), ForkCondition::Never);
     }
 }

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -182,8 +182,8 @@ pub trait OpHardforks: EthereumHardforks {
 ///
 /// Optimism can also hard fork independently of Ethereum. The relation between Ethereum and
 /// Optimism hard forks is described by predicate [`EthereumHardfork`] `=>` [`OpHardfork`], since
-/// an OP chain can have undergo an [`OpHardfork`] without an [`EthereumHardfork`], but not the
-/// other way around.
+/// an OP chain can undergo an [`OpHardfork`] without an [`EthereumHardfork`], but not the other
+/// way around.
 #[derive(Debug, Clone)]
 pub struct OpChainHardforks {
     /// Ordered list of OP hardfork activations.

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -218,7 +218,7 @@ impl OpChainHardforks {
         Self::new(OpHardfork::base_sepolia())
     }
 
-    /// Returns true if this is an OP mainnet instance.
+    /// Returns `true` if this is an OP mainnet instance.
     pub fn is_op_mainnet(&self) -> bool {
         self[OpHardfork::Bedrock] == ForkCondition::Block(OP_MAINNET_BEDROCK_BLOCK)
     }

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -108,70 +108,44 @@ impl Index<OpHardfork> for &[(OpHardfork, ForkCondition)] {
         use OpHardfork::*;
 
         match hf {
-            Bedrock => self
-                .get(0)
-                .map(|(hf, block)| {
-                    debug_assert!(matches!(hf, Bedrock));
-                    block
-                })
-                .expect("bedrock block"),
-            Regolith => self
-                .get(1)
-                .map(|(hf, time)| {
-                    debug_assert!(matches!(hf, Regolith));
-                    time
-                })
-                .expect("regolith timestamp"),
-            Canyon => self
-                .get(2)
-                .map(|(hf, time)| {
-                    debug_assert!(matches!(hf, Canyon));
-                    time
-                })
-                .expect("canyon timestamp"),
-            Ecotone => self
-                .get(3)
-                .map(|(hf, time)| {
-                    debug_assert!(matches!(hf, Ecotone));
-                    time
-                })
-                .expect("ecotone timestamp"),
-            Fjord => self
-                .get(4)
-                .map(|(hf, time)| {
-                    debug_assert!(matches!(hf, Fjord));
-                    time
-                })
-                .expect("fjord timestamp"),
-            Granite => self
-                .get(5)
-                .map(|(hf, time)| {
-                    debug_assert!(matches!(hf, Granite));
-                    time
-                })
-                .expect("granite timestamp"),
-            Holocene => self
-                .get(6)
-                .map(|(hf, time)| {
-                    debug_assert!(matches!(hf, Holocene));
-                    time
-                })
-                .expect("holocene timestamp"),
-            Isthmus => self
-                .get(7)
-                .map(|(hf, time)| {
-                    debug_assert!(matches!(hf, Isthmus));
-                    time
-                })
-                .expect("isthmus timestamp"),
-            Interop => self
-                .get(8)
-                .map(|(hf, time)| {
-                    debug_assert!(matches!(hf, Interop));
-                    time
-                })
-                .expect("interop timestamp"),
+            Bedrock => self.get(0).map(|(hf, block)| {
+                debug_assert!(matches!(hf, Bedrock));
+                block
+            }),
+            Regolith => self.get(1).map(|(hf, time)| {
+                debug_assert!(matches!(hf, Regolith));
+                time
+            }),
+            Canyon => self.get(2).map(|(hf, time)| {
+                debug_assert!(matches!(hf, Canyon));
+                time
+            }),
+            Ecotone => self.get(3).map(|(hf, time)| {
+                debug_assert!(matches!(hf, Ecotone));
+                time
+            }),
+            Fjord => self.get(4).map(|(hf, time)| {
+                debug_assert!(matches!(hf, Fjord));
+                time
+            }),
+            Granite => self.get(5).map(|(hf, time)| {
+                debug_assert!(matches!(hf, Granite));
+                time
+            }),
+            Holocene => self.get(6).map(|(hf, time)| {
+                debug_assert!(matches!(hf, Holocene));
+                time
+            }),
+            Isthmus => self.get(7).map(|(hf, time)| {
+                debug_assert!(matches!(hf, Isthmus));
+                time
+            }),
+            Interop => self.get(8).map(|(hf, time)| {
+                debug_assert!(matches!(hf, Interop));
+                time
+            }),
         }
+        .unwrap_or(&ForkCondition::Never)
     }
 }
 
@@ -266,7 +240,7 @@ impl OpChainHardforks {
 
     /// Creates a new [`OpChainHardforks`] with OP mainnet configuration.
     pub fn op_mainnet() -> Self {
-        Self::new(OpHardfork::op_mainnet(), Some(3950000))
+        Self::new(OpHardfork::op_mainnet(), Some(3_950_000))
     }
 
     /// Creates a new [`OpChainHardforks`] with OP Sepolia configuration.

--- a/crates/op-hardforks/src/optimism/mainnet.rs
+++ b/crates/op-hardforks/src/optimism/mainnet.rs
@@ -1,5 +1,9 @@
 //! Optimism Mainnet hardfork starting points
 
+//------------------------ OVM chain ------------------------//
+/// Berlin hardfork activation block
+pub const OP_MAINNET_BERLIN_BLOCK: u64 = 3_950_000;
+//------------------------ EVM chain ------------------------//
 /// Bedrock hardfork activation block
 pub const OP_MAINNET_BEDROCK_BLOCK: u64 = 105_235_063;
 /// Canyon hardfork activation timestamp

--- a/crates/op-hardforks/src/optimism/mainnet.rs
+++ b/crates/op-hardforks/src/optimism/mainnet.rs
@@ -6,6 +6,8 @@ pub const OP_MAINNET_BERLIN_BLOCK: u64 = 3_950_000;
 //------------------------ EVM chain ------------------------//
 /// Bedrock hardfork activation block
 pub const OP_MAINNET_BEDROCK_BLOCK: u64 = 105_235_063;
+/// Regolith hardfork activation timestamp
+pub const OP_MAINNET_REGOLITH_TIMESTAMP: u64 = 0;
 /// Canyon hardfork activation timestamp
 pub const OP_MAINNET_CANYON_TIMESTAMP: u64 = 1_704_992_401;
 /// Ecotone hardfork activation timestamp

--- a/crates/op-hardforks/src/optimism/sepolia.rs
+++ b/crates/op-hardforks/src/optimism/sepolia.rs
@@ -1,5 +1,9 @@
 //! Optimism Sepolia hardfork starting points
 
+/// Bedrock hardfork activation block
+pub const OP_SEPOLIA_BEDROCK_BLOCK: u64 = 0;
+/// Regolith sepolia hardfork activation timestamp
+pub const OP_SEPOLIA_REGOLITH_TIMESTAMP: u64 = 0;
 /// Canyon sepolia hardfork activation timestamp
 pub const OP_SEPOLIA_CANYON_TIMESTAMP: u64 = 1_699_981_200;
 /// Ecotone sepolia hardfork activation timestamp

--- a/crates/op-hardforks/src/optimism/sepolia.rs
+++ b/crates/op-hardforks/src/optimism/sepolia.rs
@@ -1,6 +1,6 @@
 //! Optimism Sepolia hardfork starting points
 
-/// Bedrock hardfork activation block
+/// Bedrock sepolia hardfork activation block
 pub const OP_SEPOLIA_BEDROCK_BLOCK: u64 = 0;
 /// Regolith sepolia hardfork activation timestamp
 pub const OP_SEPOLIA_REGOLITH_TIMESTAMP: u64 = 0;


### PR DESCRIPTION
- Exports op mainnet berlin block as constant and removes magic number
- Overloads index operator for `OpChainHardforks` for `OpHardfork` and `EthereumHardfork` indices
- Removes redundant berlin block variable
- Uses indexing logic in impl of `EthereumHardforks` and `OpHardforks` with index out of bounds checks
- Extends `OpChainHardforks` docs

pending tests