### PR TITLE
chore(op): Re-export `EthereumHardforks` and `ForkCondition` via `alloy-op-hardforks`

### DIFF
--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -9,7 +9,8 @@
 
 extern crate alloc;
 use alloc::vec::Vec;
-use alloy_hardforks::{hardfork, EthereumHardfork, EthereumHardforks, ForkCondition};
+use alloy_hardforks::{hardfork, EthereumHardfork};
+pub use alloy_hardforks::{EthereumHardforks, ForkCondition};
 use core::ops::Index;
 
 pub mod optimism;


### PR DESCRIPTION
Re-exports types needed to fully make use of `alloy-op-hardforks`