### PR TITLE
chore: added prague activation block for mainnet

### DIFF
--- a/crates/hardforks/src/ethereum/mainnet.rs
+++ b/crates/hardforks/src/ethereum/mainnet.rs
@@ -36,6 +36,8 @@ pub const MAINNET_PARIS_BLOCK: u64 = 15_537_394;
 pub const MAINNET_SHANGHAI_BLOCK: u64 = 17_034_870;
 /// Cancun hard fork activation block is 19426587.
 pub const MAINNET_CANCUN_BLOCK: u64 = 19_426_587;
+/// Prague hard fork activation block is 22431084.
+pub const MAINNET_PRAGUE_BLOCK: u64 = 22_431_084;
 
 /// Paris hard fork activation terminal total difficulty is 58_750_000_000_000_000_000_000_U256.
 pub const MAINNET_PARIS_TTD: U256 = uint!(58_750_000_000_000_000_000_000_U256);

--- a/crates/hardforks/src/hardfork/ethereum.rs
+++ b/crates/hardforks/src/hardfork/ethereum.rs
@@ -91,6 +91,7 @@ impl EthereumHardfork {
             Self::Paris => Some(MAINNET_PARIS_BLOCK),
             Self::Shanghai => Some(MAINNET_SHANGHAI_BLOCK),
             Self::Cancun => Some(MAINNET_CANCUN_BLOCK),
+            Self::Prague => Some(MAINNET_PRAGUE_BLOCK),
             _ => None,
         }
     }


### PR DESCRIPTION
towards [#10612](https://github.com/foundry-rs/foundry/pull/10612)

activation block referred from:
https://github.com/foundry-rs/foundry/blob/master/crates/anvil/src/hardfork.rs#L79