### PR TITLE
chore(deps): Make `serde` feature `no_std` compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,5 +45,5 @@ alloy-primitives = { version = "1.0.0", default-features = false }
 
 # misc
 auto_impl = "1"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "alloc"], default-features = false }
 dyn-clone = "1.0.17"

--- a/crates/hardforks/Cargo.toml
+++ b/crates/hardforks/Cargo.toml
@@ -28,3 +28,4 @@ serde = [
     "dep:serde",
     "alloy-primitives/serde",
 ]
+std = ["serde?/std"]

--- a/crates/op-hardforks/Cargo.toml
+++ b/crates/op-hardforks/Cargo.toml
@@ -20,4 +20,8 @@ auto_impl.workspace = true
 serde = { workspace = true, optional = true }
 
 [features]
-serde = ["dep:serde"]
+serde = [
+	"dep:serde",
+	"alloy-hardforks/serde"
+]
+std = ["serde?/std", "alloy-hardforks/std"]


### PR DESCRIPTION
## Overview

Removes the need for `std` when the `serde` feature is enabled, following a similar pattern to the rest of the `alloy` crates where, by default, [just the `alloc` and `derive` features are enabled](https://github.com/alloy-rs/alloy/blob/main/Cargo.toml#L138-L141).

Also introduces an `std` feature that will enable `serde/std` if set.