### PR TITLE
fix: Arbitrum and Holesky activated with Paris activated per block(0) at `paris`

### DIFF
--- a/crates/hardforks/src/hardfork/ethereum.rs
+++ b/crates/hardforks/src/hardfork/ethereum.rs
@@ -562,7 +562,6 @@ impl EthereumHardfork {
                 _ => Self::Prague,
             }),
             Ok(NamedChain::Holesky) => Some(match timestamp {
-                _i if timestamp < HOLESKY_PARIS_TIMESTAMP => Self::London,
                 _i if timestamp < HOLESKY_SHANGHAI_TIMESTAMP => Self::Paris,
                 _i if timestamp < HOLESKY_CANCUN_TIMESTAMP => Self::Shanghai,
                 _i if timestamp < HOLESKY_PRAGUE_TIMESTAMP => Self::Cancun,
@@ -573,13 +572,11 @@ impl EthereumHardfork {
                 _ => Self::Prague,
             }),
             Ok(NamedChain::Arbitrum) => Some(match timestamp {
-                _i if timestamp < ARBITRUM_ONE_PARIS_TIMESTAMP => Self::London,
                 _i if timestamp < ARBITRUM_ONE_SHANGHAI_TIMESTAMP => Self::Paris,
                 _i if timestamp < ARBITRUM_ONE_CANCUN_TIMESTAMP => Self::Shanghai,
                 _ => Self::Cancun,
             }),
             Ok(NamedChain::ArbitrumSepolia) => Some(match timestamp {
-                _i if timestamp < ARBITRUM_SEPOLIA_PARIS_TIMESTAMP => Self::London,
                 _i if timestamp < ARBITRUM_SEPOLIA_SHANGHAI_TIMESTAMP => Self::Paris,
                 _i if timestamp < ARBITRUM_SEPOLIA_CANCUN_TIMESTAMP => Self::Shanghai,
                 _ => Self::Cancun,


### PR DESCRIPTION
Wrongly declared `london` in https://github.com/alloy-rs/hardforks/pull/47, these all activated Paris at `block(0)`

https://github.com/alloy-rs/hardforks/blob/033fa0adee314b97be47c7e941abc5280ea0d1f2/crates/hardforks/src/hardfork/ethereum.rs#L142

https://github.com/alloy-rs/hardforks/blob/033fa0adee314b97be47c7e941abc5280ea0d1f2/crates/hardforks/src/hardfork/ethereum.rs#L189

https://github.com/alloy-rs/hardforks/blob/033fa0adee314b97be47c7e941abc5280ea0d1f2/crates/hardforks/src/hardfork/ethereum.rs#L215

Also checked op-hardfork for this, those cases are correct for Optimism and Base

No impact on existing code prior to #47 , only impacts the reverse lookup