### PR TITLE
chore: add arbitrum activation timestamps for `prague` and small improvements

### DIFF
--- a/crates/hardforks/src/arbitrum/mainnet.rs
+++ b/crates/hardforks/src/arbitrum/mainnet.rs
@@ -4,8 +4,8 @@
 pub const ARBITRUM_ONE_SHANGHAI_BLOCK: u64 = 184_097_479;
 /// Cancun arbitrum hard fork activation block is 190301729.
 pub const ARBITRUM_ONE_CANCUN_BLOCK: u64 = 190_301_729;
-/// Prague arbitrum hard fork activation block is 348346856.
-pub const ARBITRUM_ONE_PRAGUE_BLOCK: u64 = 348_346_856;
+/// Prague arbitrum hard fork activation block is 348448105.
+pub const ARBITRUM_ONE_PRAGUE_BLOCK: u64 = 348_448_105;
 
 /// Paris arbitrum hard fork activation timestamp is 1622240000.
 pub const ARBITRUM_ONE_PARIS_TIMESTAMP: u64 = 1_622_240_000;
@@ -13,5 +13,5 @@ pub const ARBITRUM_ONE_PARIS_TIMESTAMP: u64 = 1_622_240_000;
 pub const ARBITRUM_ONE_SHANGHAI_TIMESTAMP: u64 = 1_708_804_873;
 /// Cancun arbitrum hard fork activation timestamp is 1710424089.
 pub const ARBITRUM_ONE_CANCUN_TIMESTAMP: u64 = 1_710_424_089;
-/// Prague arbitrum hard fork activation timestamp is 1750176000.
-pub const ARBITRUM_ONE_PRAGUE_TIMESTAMP: u64 = 1_750_176_000;
+/// Prague arbitrum hard fork activation timestamp is 1750201532.
+pub const ARBITRUM_ONE_PRAGUE_TIMESTAMP: u64 = 1_750_201_532;

--- a/crates/hardforks/src/arbitrum/mainnet.rs
+++ b/crates/hardforks/src/arbitrum/mainnet.rs
@@ -4,6 +4,8 @@
 pub const ARBITRUM_ONE_SHANGHAI_BLOCK: u64 = 184_097_479;
 /// Cancun arbitrum hard fork activation block is 190301729.
 pub const ARBITRUM_ONE_CANCUN_BLOCK: u64 = 190_301_729;
+/// Prague arbitrum hard fork activation block is 348346856.
+pub const ARBITRUM_ONE_PRAGUE_BLOCK: u64 = 348_346_856;
 
 /// Paris arbitrum hard fork activation timestamp is 1622240000.
 pub const ARBITRUM_ONE_PARIS_TIMESTAMP: u64 = 1_622_240_000;

--- a/crates/hardforks/src/arbitrum/mainnet.rs
+++ b/crates/hardforks/src/arbitrum/mainnet.rs
@@ -11,3 +11,5 @@ pub const ARBITRUM_ONE_PARIS_TIMESTAMP: u64 = 1_622_240_000;
 pub const ARBITRUM_ONE_SHANGHAI_TIMESTAMP: u64 = 1_708_804_873;
 /// Cancun arbitrum hard fork activation timestamp is 1710424089.
 pub const ARBITRUM_ONE_CANCUN_TIMESTAMP: u64 = 1_710_424_089;
+/// Prague arbitrum hard fork activation timestamp is 1750176000.
+pub const ARBITRUM_ONE_PRAGUE_TIMESTAMP: u64 = 1_750_176_000;

--- a/crates/hardforks/src/arbitrum/sepolia.rs
+++ b/crates/hardforks/src/arbitrum/sepolia.rs
@@ -4,6 +4,8 @@
 pub const ARBITRUM_SEPOLIA_SHANGHAI_BLOCK: u64 = 10_653_737;
 /// Cancun arbitrum sepolia hard fork activation block is 18683405.
 pub const ARBITRUM_SEPOLIA_CANCUN_BLOCK: u64 = 18_683_405;
+/// Prague arbitrum sepolia hard fork activation block is 149799168.
+pub const ARBITRUM_SEPOLIA_PRAGUE_BLOCK: u64 = 149_799_168;
 
 /// Paris arbitrum sepolia hard fork activation timestamp is 1692726996.
 pub const ARBITRUM_SEPOLIA_PARIS_TIMESTAMP: u64 = 1_692_726_996;

--- a/crates/hardforks/src/arbitrum/sepolia.rs
+++ b/crates/hardforks/src/arbitrum/sepolia.rs
@@ -11,3 +11,5 @@ pub const ARBITRUM_SEPOLIA_PARIS_TIMESTAMP: u64 = 1_692_726_996;
 pub const ARBITRUM_SEPOLIA_SHANGHAI_TIMESTAMP: u64 = 1_706_634_000;
 /// Cancun arbitrum sepolia hard fork activation timestamp is 1709229600.
 pub const ARBITRUM_SEPOLIA_CANCUN_TIMESTAMP: u64 = 1_709_229_600;
+/// Prague arbitrum sepolia hard fork activation timestamp is 1746543285.
+pub const ARBITRUM_SEPOLIA_PRAGUE_TIMESTAMP: u64 = 1_746_543_285;

--- a/crates/hardforks/src/ethereum/holesky.rs
+++ b/crates/hardforks/src/ethereum/holesky.rs
@@ -4,6 +4,8 @@
 pub const HOLESKY_SHANGHAI_BLOCK: u64 = 6_698;
 /// Cancun holesky hard fork activation block is 894733.
 pub const HOLESKY_CANCUN_BLOCK: u64 = 894_733;
+/// Prague holesky hard fork activation block is 3419704.
+pub const HOLESKY_PRAGUE_BLOCK: u64 = 3_419_704;
 
 /// Paris holesky hard fork activation timestamp is 1695902100.
 pub const HOLESKY_PARIS_TIMESTAMP: u64 = 1_695_902_100;

--- a/crates/hardforks/src/ethereum/hoodi.rs
+++ b/crates/hardforks/src/ethereum/hoodi.rs
@@ -1,4 +1,7 @@
 //! Hoodi hardfork starting points
 
+/// Prague hoodi hard fork activation block is 60412.
+pub const HOODI_PRAGUE_BLOCK: u64 = 60412;
+
 /// Prague hoodi hard fork activation timestamp is 1742999832.
 pub const HOODI_PRAGUE_TIMESTAMP: u64 = 1_742_999_832;

--- a/crates/hardforks/src/ethereum/sepolia.rs
+++ b/crates/hardforks/src/ethereum/sepolia.rs
@@ -12,6 +12,8 @@ pub const SEPOLIA_PARIS_FORK_BLOCK: u64 = 1_735_371;
 pub const SEPOLIA_SHANGHAI_BLOCK: u64 = 2_990_908;
 /// Cancun sepolia hard fork activation block is 5187023.
 pub const SEPOLIA_CANCUN_BLOCK: u64 = 5_187_023;
+/// Prague sepolia hard fork activation block is 7836331.
+pub const SEPOLIA_PRAGUE_BLOCK: u64 = 7_836_331;
 
 /// Paris sepolia hard fork activation timestamp is 1633267481.
 pub const SEPOLIA_PARIS_TIMESTAMP: u64 = 1_633_267_481;

--- a/crates/hardforks/src/hardfork/ethereum.rs
+++ b/crates/hardforks/src/hardfork/ethereum.rs
@@ -358,9 +358,8 @@ impl EthereumHardfork {
             | Self::GrayGlacier
             | Self::Paris => Some(ARBITRUM_SEPOLIA_PARIS_TIMESTAMP),
             Self::Shanghai => Some(ARBITRUM_SEPOLIA_SHANGHAI_TIMESTAMP),
-            // Hardfork::ArbOS11 => Some(1706634000),
             Self::Cancun => Some(ARBITRUM_SEPOLIA_CANCUN_TIMESTAMP),
-            // Hardfork::ArbOS20Atlas => Some(1709229600),
+            Self::Prague => Some(ARBITRUM_SEPOLIA_PRAGUE_TIMESTAMP),
             _ => None,
         }
     }
@@ -384,9 +383,8 @@ impl EthereumHardfork {
             | Self::GrayGlacier
             | Self::Paris => Some(ARBITRUM_ONE_PARIS_TIMESTAMP),
             Self::Shanghai => Some(ARBITRUM_ONE_SHANGHAI_TIMESTAMP),
-            // Hardfork::ArbOS11 => Some(1708804873),
             Self::Cancun => Some(ARBITRUM_ONE_CANCUN_TIMESTAMP),
-            // Hardfork::ArbOS20Atlas => Some(1710424089),
+            Self::Prague => Some(ARBITRUM_ONE_PRAGUE_TIMESTAMP),
             _ => None,
         }
     }
@@ -775,30 +773,60 @@ mod tests {
         let test_cases = [
             // (chain_id, timestamp, expected) - Key transitions for each chain
             // Mainnet
+            // At block 0: Frontier
+            (1, MAINNET_FRONTIER_TIMESTAMP - 1, EthereumHardfork::Frontier),
             (1, MAINNET_FRONTIER_TIMESTAMP, EthereumHardfork::Frontier),
+            (1, MAINNET_HOMESTEAD_TIMESTAMP, EthereumHardfork::Homestead),
+            (1, MAINNET_DAO_TIMESTAMP, EthereumHardfork::Dao),
+            (1, MAINNET_TANGERINE_TIMESTAMP, EthereumHardfork::Tangerine),
+            (1, MAINNET_SPURIOUS_DRAGON_TIMESTAMP, EthereumHardfork::SpuriousDragon),
+            (1, MAINNET_BYZANTIUM_TIMESTAMP, EthereumHardfork::Byzantium),
+            (1, MAINNET_PETERSBURG_TIMESTAMP, EthereumHardfork::Petersburg),
+            (1, MAINNET_ISTANBUL_TIMESTAMP, EthereumHardfork::Istanbul),
+            (1, MAINNET_MUIR_GLACIER_TIMESTAMP, EthereumHardfork::MuirGlacier),
+            (1, MAINNET_BERLIN_TIMESTAMP, EthereumHardfork::Berlin),
             (1, MAINNET_LONDON_TIMESTAMP, EthereumHardfork::London),
+            (1, MAINNET_ARROW_GLACIER_TIMESTAMP, EthereumHardfork::ArrowGlacier),
+            (1, MAINNET_GRAY_GLACIER_TIMESTAMP, EthereumHardfork::GrayGlacier),
+            (1, MAINNET_PARIS_TIMESTAMP, EthereumHardfork::Paris),
             (1, MAINNET_SHANGHAI_TIMESTAMP, EthereumHardfork::Shanghai),
             (1, MAINNET_CANCUN_TIMESTAMP, EthereumHardfork::Cancun),
-            (1, MAINNET_HOMESTEAD_TIMESTAMP - 1, EthereumHardfork::Frontier),
-            (1, MAINNET_PRAGUE_TIMESTAMP + 1000, EthereumHardfork::Prague),
             // Sepolia
+            // At block 0: London
+            (11155111, SEPOLIA_PARIS_TIMESTAMP - 1, EthereumHardfork::London),
             (11155111, SEPOLIA_PARIS_TIMESTAMP, EthereumHardfork::Paris),
+            (11155111, SEPOLIA_SHANGHAI_TIMESTAMP - 1, EthereumHardfork::Paris),
             (11155111, SEPOLIA_SHANGHAI_TIMESTAMP, EthereumHardfork::Shanghai),
             (11155111, SEPOLIA_CANCUN_TIMESTAMP, EthereumHardfork::Cancun),
-            (11155111, SEPOLIA_PARIS_TIMESTAMP - 1, EthereumHardfork::London),
+            (11155111, SEPOLIA_PRAGUE_TIMESTAMP - 1, EthereumHardfork::Cancun),
+            (11155111, SEPOLIA_PRAGUE_TIMESTAMP + 1, EthereumHardfork::Prague),
             // Holesky
+            // At block 0: Paris
+            (17000, HOLESKY_PARIS_TIMESTAMP - 1, EthereumHardfork::Paris),
+            (17000, HOLESKY_PARIS_TIMESTAMP, EthereumHardfork::Paris),
+            (17000, HOLESKY_SHANGHAI_TIMESTAMP - 1, EthereumHardfork::Paris),
             (17000, HOLESKY_SHANGHAI_TIMESTAMP, EthereumHardfork::Shanghai),
             (17000, HOLESKY_CANCUN_TIMESTAMP, EthereumHardfork::Cancun),
-            (17000, HOLESKY_SHANGHAI_TIMESTAMP - 1, EthereumHardfork::Paris),
+            (17000, HOLESKY_PRAGUE_TIMESTAMP - 1, EthereumHardfork::Cancun),
+            (17000, HOLESKY_PRAGUE_TIMESTAMP + 1, EthereumHardfork::Prague),
             // Arbitrum One
+            // At block 0: Paris
+            (42161, ARBITRUM_ONE_PARIS_TIMESTAMP - 1, EthereumHardfork::Paris),
+            (42161, ARBITRUM_ONE_PARIS_TIMESTAMP, EthereumHardfork::Paris),
+            (42161, ARBITRUM_ONE_SHANGHAI_TIMESTAMP - 1, EthereumHardfork::Paris),
             (42161, ARBITRUM_ONE_SHANGHAI_TIMESTAMP, EthereumHardfork::Shanghai),
             (42161, ARBITRUM_ONE_CANCUN_TIMESTAMP, EthereumHardfork::Cancun),
-            (42161, ARBITRUM_ONE_SHANGHAI_TIMESTAMP - 1, EthereumHardfork::Paris),
-            (42161, ARBITRUM_ONE_CANCUN_TIMESTAMP + 1000, EthereumHardfork::Cancun),
+            (42161, ARBITRUM_ONE_PRAGUE_TIMESTAMP - 1, EthereumHardfork::Cancun),
+            (42161, ARBITRUM_ONE_PRAGUE_TIMESTAMP + 1, EthereumHardfork::Prague),
             // Arbitrum Sepolia
+            // At block 0: Paris
+            (421614, ARBITRUM_SEPOLIA_PARIS_TIMESTAMP - 1, EthereumHardfork::Paris),
+            (421614, ARBITRUM_SEPOLIA_PARIS_TIMESTAMP, EthereumHardfork::Paris),
+            (421614, ARBITRUM_SEPOLIA_SHANGHAI_TIMESTAMP - 1, EthereumHardfork::Paris),
             (421614, ARBITRUM_SEPOLIA_SHANGHAI_TIMESTAMP, EthereumHardfork::Shanghai),
             (421614, ARBITRUM_SEPOLIA_CANCUN_TIMESTAMP, EthereumHardfork::Cancun),
-            (421614, ARBITRUM_SEPOLIA_SHANGHAI_TIMESTAMP - 1, EthereumHardfork::Paris),
+            (421614, ARBITRUM_SEPOLIA_PRAGUE_TIMESTAMP - 1, EthereumHardfork::Cancun),
+            (421614, ARBITRUM_SEPOLIA_PRAGUE_TIMESTAMP + 1, EthereumHardfork::Prague),
         ];
 
         for (chain_id, timestamp, expected) in test_cases {

--- a/crates/hardforks/src/hardfork/ethereum.rs
+++ b/crates/hardforks/src/hardfork/ethereum.rs
@@ -188,9 +188,8 @@ impl EthereumHardfork {
             | Self::GrayGlacier
             | Self::Paris => Some(0),
             Self::Shanghai => Some(ARBITRUM_SEPOLIA_SHANGHAI_BLOCK),
-            // Hardfork::ArbOS11 => Some(10653737),
             Self::Cancun => Some(ARBITRUM_SEPOLIA_CANCUN_BLOCK),
-            // Hardfork::ArbOS20Atlas => Some(18683405),
+            Self::Prague => Some(ARBITRUM_SEPOLIA_PRAGUE_BLOCK),
             _ => None,
         }
     }
@@ -214,9 +213,8 @@ impl EthereumHardfork {
             | Self::GrayGlacier
             | Self::Paris => Some(0),
             Self::Shanghai => Some(ARBITRUM_ONE_SHANGHAI_BLOCK),
-            // Hardfork::ArbOS11 => Some(184097479),
             Self::Cancun => Some(ARBITRUM_ONE_CANCUN_BLOCK),
-            // Hardfork::ArbOS20Atlas => Some(190301729),
+            Self::Prague => Some(ARBITRUM_ONE_PRAGUE_BLOCK),
             _ => None,
         }
     }

--- a/crates/hardforks/src/hardfork/ethereum.rs
+++ b/crates/hardforks/src/hardfork/ethereum.rs
@@ -562,7 +562,6 @@ impl EthereumHardfork {
                 _ => Self::Prague,
             }),
             Ok(NamedChain::Holesky) => Some(match timestamp {
-                _i if timestamp < HOLESKY_PARIS_TIMESTAMP => Self::London,
                 _i if timestamp < HOLESKY_SHANGHAI_TIMESTAMP => Self::Paris,
                 _i if timestamp < HOLESKY_CANCUN_TIMESTAMP => Self::Shanghai,
                 _i if timestamp < HOLESKY_PRAGUE_TIMESTAMP => Self::Cancun,
@@ -573,16 +572,16 @@ impl EthereumHardfork {
                 _ => Self::Prague,
             }),
             Ok(NamedChain::Arbitrum) => Some(match timestamp {
-                _i if timestamp < ARBITRUM_ONE_PARIS_TIMESTAMP => Self::London,
                 _i if timestamp < ARBITRUM_ONE_SHANGHAI_TIMESTAMP => Self::Paris,
                 _i if timestamp < ARBITRUM_ONE_CANCUN_TIMESTAMP => Self::Shanghai,
-                _ => Self::Cancun,
+                _i if timestamp < ARBITRUM_ONE_PRAGUE_TIMESTAMP => Self::Cancun,
+                _ => Self::Prague,
             }),
             Ok(NamedChain::ArbitrumSepolia) => Some(match timestamp {
-                _i if timestamp < ARBITRUM_SEPOLIA_PARIS_TIMESTAMP => Self::London,
                 _i if timestamp < ARBITRUM_SEPOLIA_SHANGHAI_TIMESTAMP => Self::Paris,
                 _i if timestamp < ARBITRUM_SEPOLIA_CANCUN_TIMESTAMP => Self::Shanghai,
-                _ => Self::Cancun,
+                _i if timestamp < ARBITRUM_SEPOLIA_PRAGUE_TIMESTAMP => Self::Cancun,
+                _ => Self::Prague,
             }),
             _ => None,
         }

--- a/crates/hardforks/src/hardfork/ethereum.rs
+++ b/crates/hardforks/src/hardfork/ethereum.rs
@@ -102,9 +102,6 @@ impl EthereumHardfork {
     /// Retrieves the activation block for the specified hardfork on the Sepolia testnet.
     pub const fn sepolia_activation_block(&self) -> Option<u64> {
         match self {
-            Self::Paris => Some(SEPOLIA_PARIS_BLOCK),
-            Self::Shanghai => Some(SEPOLIA_SHANGHAI_BLOCK),
-            Self::Cancun => Some(SEPOLIA_CANCUN_BLOCK),
             Self::Frontier
             | Self::Homestead
             | Self::Dao
@@ -119,6 +116,10 @@ impl EthereumHardfork {
             | Self::London
             | Self::ArrowGlacier
             | Self::GrayGlacier => Some(0),
+            Self::Paris => Some(SEPOLIA_PARIS_BLOCK),
+            Self::Shanghai => Some(SEPOLIA_SHANGHAI_BLOCK),
+            Self::Cancun => Some(SEPOLIA_CANCUN_BLOCK),
+            Self::Prague => Some(SEPOLIA_PRAGUE_BLOCK),
             _ => None,
         }
     }
@@ -142,6 +143,7 @@ impl EthereumHardfork {
             | Self::Paris => Some(0),
             Self::Shanghai => Some(HOLESKY_SHANGHAI_BLOCK),
             Self::Cancun => Some(HOLESKY_CANCUN_BLOCK),
+            Self::Prague => Some(HOLESKY_PRAGUE_BLOCK),
             _ => None,
         }
     }
@@ -165,6 +167,7 @@ impl EthereumHardfork {
             | Self::Paris
             | Self::Shanghai
             | Self::Cancun => Some(0),
+            Self::Prague => Some(HOODI_PRAGUE_BLOCK),
             _ => None,
         }
     }


### PR DESCRIPTION
Closes: https://github.com/alloy-rs/hardforks/issues/49

Adds block numbers for Prague for `hoodi`, `sepolia`, `holesky`. Used `cast find-block <timestamp> --rpc-url <rpc_url>` to find the block numbers.

ArbOS 40 is live but the https://docs.arbitrum.foundation/network-upgrades page has not been updated to reflect the exact transaction. I asked on the Arbitrum Discord and they confirmed below:

Arbitrum Sepolia: https://sepolia.arbiscan.io/tx/0xce8d716391583d10e6c7b27d17118b9e2845cbb44321b466adff1b9168603a40
Arbitrum: https://arbiscan.io/tx/0xfcbe6cb3dcb58b1c201b02f7f8649a48083b581c1ecebd356fe961185882a907

Expanded tests to make better assertions around the 0 block and which hardfork was active at the time.