### PR TITLE
chore: rm std feature

### DIFF
--- a/crates/hardforks/Cargo.toml
+++ b/crates/hardforks/Cargo.toml
@@ -28,4 +28,3 @@ serde = [
     "dep:serde",
     "alloy-primitives/serde",
 ]
-std = ["serde?/std"]

--- a/crates/op-hardforks/Cargo.toml
+++ b/crates/op-hardforks/Cargo.toml
@@ -25,4 +25,3 @@ serde = [
 	"dep:serde",
 	"alloy-hardforks/serde"
 ]
-std = ["serde?/std", "alloy-hardforks/std"]


### PR DESCRIPTION
introduced in #48

we dont need this because we dont link the std lib and dont use any of serde's std features

https://github.com/alloy-rs/hardforks/blob/62d9d0ecc4913549596ba423ae8fdcde245a15a1/crates/hardforks/src/lib.rs#L8-L8