### PR TITLE
chore: use alloy-chains `Chain` for `from_chain_and_timestamp` 

### DIFF
--- a/crates/hardforks/src/hardfork/ethereum.rs
+++ b/crates/hardforks/src/hardfork/ethereum.rs
@@ -533,7 +533,7 @@ impl EthereumHardfork {
     /// Reverse lookup to find the hardfork given a chain ID and block timestamp.
     /// Returns the active hardfork at the given timestamp for the specified chain.
     pub fn from_chain_and_timestamp(chain: Chain, timestamp: u64) -> Option<Self> {
-        let named = NamedChain::try_from(chain.id()).ok()?;
+        let named = chain.named()?;
 
         match named {
             NamedChain::Mainnet => Some(match timestamp {

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -54,7 +54,7 @@ impl OpHardfork {
     /// Reverse lookup to find the hardfork given a chain ID and block timestamp.
     /// Returns the active hardfork at the given timestamp for the specified OP chain.
     pub fn from_chain_and_timestamp(chain: Chain, timestamp: u64) -> Option<Self> {
-        let named = NamedChain::try_from(chain.id()).ok()?;
+        let named = chain.named()?;
 
         match named {
             NamedChain::Optimism => Some(match timestamp {


### PR DESCRIPTION
Considering we already use `alloy-chains` here it is more user friendly to use `Chain` rather than `u64`.

Improves test suite by using `Chain::<foo>` instead of hardcoded chain ids, split out `named` cast to avoid recompute, avoid casting if `NamedChain` is passed.