### PR TITLE
fix(op): Fix jovian activation method name to indicate timestamp activation

### DIFF
--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -214,7 +214,7 @@ pub trait OpHardforks: EthereumHardforks {
 
     /// Returns `true` if [`Jovian`](OpHardfork::Jovian) is active at given block
     /// timestamp.
-    fn is_jovian_active_at_block(&self, timestamp: u64) -> bool {
+    fn is_jovian_active_at_timestamp(&self, timestamp: u64) -> bool {
         self.op_fork_activation(OpHardfork::Jovian).active_at_timestamp(timestamp)
     }
 


### PR DESCRIPTION
Change method name `is_jovian_active_at_block`->`is_jovian_active_at_timestamp`