### PR TITLE
feat: added amsterdam hardfork

### DIFF
--- a/crates/hardforks/src/hardfork/ethereum.rs
+++ b/crates/hardforks/src/hardfork/ethereum.rs
@@ -63,6 +63,8 @@ hardfork!(
         Bpo4,
         /// BPO 5
         Bpo5,
+        /// Amsterdam: <https://eips.ethereum.org/EIPS/eip-7773>
+        Amsterdam,
     }
 );
 
@@ -636,6 +638,12 @@ pub trait EthereumHardforks {
     /// Convenience method to check if [`EthereumHardfork::Osaka`] is active at a given timestamp.
     fn is_osaka_active_at_timestamp(&self, timestamp: u64) -> bool {
         self.is_ethereum_fork_active_at_timestamp(EthereumHardfork::Osaka, timestamp)
+    }
+
+    /// Convenience method to check if [`EthereumHardfork::Amsterdam`] is active at a given
+    /// timestamp.
+    fn is_amsterdam_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.is_ethereum_fork_active_at_timestamp(EthereumHardfork::Amsterdam, timestamp)
     }
 
     /// Convenience method to check if [`EthereumHardfork::Byzantium`] is active at a given block

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -345,7 +345,7 @@ impl Index<EthereumHardfork> for OpChainHardforks {
             Shanghai => &self[Canyon],
             Cancun => &self[Ecotone],
             Prague => &self[Isthmus],
-            Osaka | Bpo1 | Bpo2 | Bpo3 | Bpo4 | Bpo5 => panic!("index out of bounds"),
+            Osaka | Bpo1 | Bpo2 | Bpo3 | Bpo4 | Bpo5 | Amsterdam => panic!("index out of bounds"),
         }
     }
 }


### PR DESCRIPTION
Amsterdam is missing from the list of Ethereum Hardforks, need that for [BAL](https://eips.ethereum.org/EIPS/eip-7928).