### PR TITLE
feat(hardforks): Add activation helpers for pre-merge forks

### DIFF
--- a/crates/hardforks/src/hardfork/ethereum.rs
+++ b/crates/hardforks/src/hardfork/ethereum.rs
@@ -625,7 +625,7 @@ pub trait EthereumHardforks {
         self.is_ethereum_fork_active_at_block(EthereumHardfork::Homestead, block_number)
     }
 
-    /// Convenience method to check if [`EthereumHardfork::TangerineWhistle`] is active at a given
+    /// Convenience method to check if [`EthereumHardfork::Tangerine`] is active at a given
     /// block number.
     fn is_tangerine_whistle_active_at_block(&self, block_number: u64) -> bool {
         self.is_ethereum_fork_active_at_block(EthereumHardfork::Tangerine, block_number)


### PR DESCRIPTION
This adds missing activation helpers (is_berlin_active_at_block, etc.) to the EthereumHardforks trait and reorders existing helpers chronologically.

These functions are needed to simplify hardfork mapping in Reth. This change is part of the work to resolve paradigmxyz/reth#18150.