### PR TITLE
chore: remove local outdated `SECURITY.md` to use org-level `SECURITY.md`

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,0 @@
-# Security Policy
-
-## Reporting a Vulnerability
-
-Contact georgios at paradigm.xyz.


### PR DESCRIPTION
Removes local outdated `SECURITY.md` with org-level `SECURITY.md` added in https://github.com/alloy-rs/.github/pull/2

It will show the `Security` tab, e.g. https://github.com/alloy-rs/chains