### PR TITLE
fix(op-hardforks): update impl `Index<EthereumHardfork>` for `OpChainHardforks`

### DIFF
--- a/crates/op-hardforks/Cargo.toml
+++ b/crates/op-hardforks/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 alloy-hardforks.workspace = true
 alloy-chains.workspace = true
+alloy-primitives.workspace = true
 
 auto_impl.workspace = true
 serde = { workspace = true, optional = true }


### PR DESCRIPTION
Closes #65 and unlocks https://github.com/paradigmxyz/reth/pull/18486

- Paris hardfork with TTD fork condition
- Dao hardfork not activated
- Replaced panic! out of bound with ForkCondition Never variant for more robustness

Related: #64 