### PR TITLE
chore: add bpo hardforks

### DIFF
--- a/crates/hardforks/src/ethereum/holesky.rs
+++ b/crates/hardforks/src/ethereum/holesky.rs
@@ -21,5 +21,5 @@ pub const HOLESKY_OSAKA_TIMESTAMP: u64 = 1_759_308_480;
 /// BPO1 hardfork activation timestamp
 pub const HOLESKY_BPO1_TIMESTAMP: u64 = 1759800000;
 
-/// BPO1 hardfork activation timestamp
+/// BPO2 hardfork activation timestamp
 pub const HOLESKY_BPO2_TIMESTAMP: u64 = 1760389824;

--- a/crates/hardforks/src/ethereum/holesky.rs
+++ b/crates/hardforks/src/ethereum/holesky.rs
@@ -17,3 +17,9 @@ pub const HOLESKY_CANCUN_TIMESTAMP: u64 = 1_707_305_664;
 pub const HOLESKY_PRAGUE_TIMESTAMP: u64 = 1_740_434_112;
 /// Osaka holesky hard fork activation timestamp is 1759308480.
 pub const HOLESKY_OSAKA_TIMESTAMP: u64 = 1_759_308_480;
+
+/// BPO1 hardfork activation timestamp
+pub const HOLESKY_BPO1_TIMESTAMP: u64 = 1759800000;
+
+/// BPO1 hardfork activation timestamp
+pub const HOLESKY_BPO2_TIMESTAMP: u64 = 1760389824;

--- a/crates/hardforks/src/ethereum/hoodi.rs
+++ b/crates/hardforks/src/ethereum/hoodi.rs
@@ -7,3 +7,9 @@ pub const HOODI_PRAGUE_BLOCK: u64 = 60412;
 pub const HOODI_PRAGUE_TIMESTAMP: u64 = 1_742_999_832;
 /// Osaka hoodi hard fork activation timestamp is 1761677592.
 pub const HOODI_OSAKA_TIMESTAMP: u64 = 1_761_677_592;
+
+/// BPO1 hardfork activation timestamp
+pub const HOODI_BPO1_TIMESTAMP: u64 = 1761677592;
+
+/// BPO1 hardfork activation timestamp
+pub const HOODI_BPO2_TIMESTAMP: u64 = 1762365720;

--- a/crates/hardforks/src/ethereum/hoodi.rs
+++ b/crates/hardforks/src/ethereum/hoodi.rs
@@ -9,7 +9,7 @@ pub const HOODI_PRAGUE_TIMESTAMP: u64 = 1_742_999_832;
 pub const HOODI_OSAKA_TIMESTAMP: u64 = 1_761_677_592;
 
 /// BPO1 hardfork activation timestamp
-pub const HOODI_BPO1_TIMESTAMP: u64 = 1761677592;
+pub const HOODI_BPO1_TIMESTAMP: u64 = 1762365720;
 
 /// BPO2 hardfork activation timestamp
-pub const HOODI_BPO2_TIMESTAMP: u64 = 1762365720;
+pub const HOODI_BPO2_TIMESTAMP: u64 = 1762955544;

--- a/crates/hardforks/src/ethereum/hoodi.rs
+++ b/crates/hardforks/src/ethereum/hoodi.rs
@@ -11,5 +11,5 @@ pub const HOODI_OSAKA_TIMESTAMP: u64 = 1_761_677_592;
 /// BPO1 hardfork activation timestamp
 pub const HOODI_BPO1_TIMESTAMP: u64 = 1761677592;
 
-/// BPO1 hardfork activation timestamp
+/// BPO2 hardfork activation timestamp
 pub const HOODI_BPO2_TIMESTAMP: u64 = 1762365720;

--- a/crates/hardforks/src/ethereum/mainnet.rs
+++ b/crates/hardforks/src/ethereum/mainnet.rs
@@ -81,3 +81,9 @@ pub const MAINNET_CANCUN_TIMESTAMP: u64 = 1_710_338_135;
 pub const MAINNET_PRAGUE_TIMESTAMP: u64 = 1_746_612_311;
 /// Osaka hard fork activation timestamp is 1764798551.
 pub const MAINNET_OSAKA_TIMESTAMP: u64 = 1_764_798_551;
+
+/// BPO1 hardfork activation timestamp
+pub const MAINNET_BPO1_TIMESTAMP: u64 = 1765978199;
+
+/// BPO1 hardfork activation timestamp
+pub const MAINNET_BPO2_TIMESTAMP: u64 = 1767747671;

--- a/crates/hardforks/src/ethereum/mainnet.rs
+++ b/crates/hardforks/src/ethereum/mainnet.rs
@@ -85,5 +85,5 @@ pub const MAINNET_OSAKA_TIMESTAMP: u64 = 1_764_798_551;
 /// BPO1 hardfork activation timestamp
 pub const MAINNET_BPO1_TIMESTAMP: u64 = 1765978199;
 
-/// BPO1 hardfork activation timestamp
+/// BPO2 hardfork activation timestamp
 pub const MAINNET_BPO2_TIMESTAMP: u64 = 1767747671;

--- a/crates/hardforks/src/ethereum/sepolia.rs
+++ b/crates/hardforks/src/ethereum/sepolia.rs
@@ -25,3 +25,9 @@ pub const SEPOLIA_CANCUN_TIMESTAMP: u64 = 1_706_655_072;
 pub const SEPOLIA_PRAGUE_TIMESTAMP: u64 = 1_741_159_776;
 /// Osaka sepolia hard fork activation timestamp is 1760427360.
 pub const SEPOLIA_OSAKA_TIMESTAMP: u64 = 1_760_427_360;
+
+/// BPO1 hardfork activation timestamp
+pub const SEPOLIA_BPO1_TIMESTAMP: u64 = 1761017184;
+
+/// BPO1 hardfork activation timestamp
+pub const SEPOLIA_BPO2_TIMESTAMP: u64 = 1761607008;

--- a/crates/hardforks/src/ethereum/sepolia.rs
+++ b/crates/hardforks/src/ethereum/sepolia.rs
@@ -29,5 +29,5 @@ pub const SEPOLIA_OSAKA_TIMESTAMP: u64 = 1_760_427_360;
 /// BPO1 hardfork activation timestamp
 pub const SEPOLIA_BPO1_TIMESTAMP: u64 = 1761017184;
 
-/// BPO1 hardfork activation timestamp
+/// BPO2 hardfork activation timestamp
 pub const SEPOLIA_BPO2_TIMESTAMP: u64 = 1761607008;

--- a/crates/hardforks/src/hardfork/ethereum.rs
+++ b/crates/hardforks/src/hardfork/ethereum.rs
@@ -410,7 +410,7 @@ impl EthereumHardfork {
     }
 
     /// Ethereum mainnet list of hardforks.
-    pub const fn mainnet() -> [(Self, ForkCondition); 19] {
+    pub const fn mainnet() -> [(Self, ForkCondition); 21] {
         [
             (Self::Frontier, ForkCondition::Block(MAINNET_FRONTIER_BLOCK)),
             (Self::Homestead, ForkCondition::Block(MAINNET_HOMESTEAD_BLOCK)),
@@ -438,11 +438,13 @@ impl EthereumHardfork {
             (Self::Cancun, ForkCondition::Timestamp(MAINNET_CANCUN_TIMESTAMP)),
             (Self::Prague, ForkCondition::Timestamp(MAINNET_PRAGUE_TIMESTAMP)),
             (Self::Osaka, ForkCondition::Timestamp(MAINNET_OSAKA_TIMESTAMP)),
+            (Self::Bpo1, ForkCondition::Timestamp(MAINNET_BPO1_TIMESTAMP)),
+            (Self::Bpo2, ForkCondition::Timestamp(MAINNET_BPO2_TIMESTAMP)),
         ]
     }
 
     /// Ethereum sepolia list of hardforks.
-    pub const fn sepolia() -> [(Self, ForkCondition); 17] {
+    pub const fn sepolia() -> [(Self, ForkCondition); 19] {
         [
             (Self::Frontier, ForkCondition::Block(0)),
             (Self::Homestead, ForkCondition::Block(0)),
@@ -468,11 +470,13 @@ impl EthereumHardfork {
             (Self::Cancun, ForkCondition::Timestamp(SEPOLIA_CANCUN_TIMESTAMP)),
             (Self::Prague, ForkCondition::Timestamp(SEPOLIA_PRAGUE_TIMESTAMP)),
             (Self::Osaka, ForkCondition::Timestamp(SEPOLIA_OSAKA_TIMESTAMP)),
+            (Self::Bpo1, ForkCondition::Timestamp(SEPOLIA_BPO1_TIMESTAMP)),
+            (Self::Bpo2, ForkCondition::Timestamp(SEPOLIA_BPO2_TIMESTAMP)),
         ]
     }
 
     /// Ethereum holesky list of hardforks.
-    pub const fn holesky() -> [(Self, ForkCondition); 17] {
+    pub const fn holesky() -> [(Self, ForkCondition); 19] {
         [
             (Self::Frontier, ForkCondition::Block(0)),
             (Self::Homestead, ForkCondition::Block(0)),
@@ -498,11 +502,13 @@ impl EthereumHardfork {
             (Self::Cancun, ForkCondition::Timestamp(HOLESKY_CANCUN_TIMESTAMP)),
             (Self::Prague, ForkCondition::Timestamp(HOLESKY_PRAGUE_TIMESTAMP)),
             (Self::Osaka, ForkCondition::Timestamp(HOLESKY_OSAKA_TIMESTAMP)),
+            (Self::Bpo1, ForkCondition::Timestamp(HOLESKY_BPO1_TIMESTAMP)),
+            (Self::Bpo2, ForkCondition::Timestamp(HOLESKY_BPO2_TIMESTAMP)),
         ]
     }
 
     /// Ethereum Hoodi list of hardforks.
-    pub const fn hoodi() -> [(Self, ForkCondition); 17] {
+    pub const fn hoodi() -> [(Self, ForkCondition); 19] {
         [
             (Self::Frontier, ForkCondition::Block(0)),
             (Self::Homestead, ForkCondition::Block(0)),
@@ -528,6 +534,8 @@ impl EthereumHardfork {
             (Self::Cancun, ForkCondition::Timestamp(0)),
             (Self::Prague, ForkCondition::Timestamp(HOODI_PRAGUE_TIMESTAMP)),
             (Self::Osaka, ForkCondition::Timestamp(HOODI_OSAKA_TIMESTAMP)),
+            (Self::Bpo1, ForkCondition::Timestamp(HOODI_BPO1_TIMESTAMP)),
+            (Self::Bpo2, ForkCondition::Timestamp(HOODI_BPO2_TIMESTAMP)),
         ]
     }
 


### PR DESCRIPTION
ref https://notes.ethereum.org/@bbusa/fusaka-bpo-timeline

adds missing BPO activation timestamps