### PR TITLE
fix(jovian/stamps): revised jovian timestamps

### DIFF
--- a/crates/op-hardforks/src/base/sepolia.rs
+++ b/crates/op-hardforks/src/base/sepolia.rs
@@ -18,5 +18,5 @@ pub const BASE_SEPOLIA_GRANITE_TIMESTAMP: u64 = OP_SEPOLIA_GRANITE_TIMESTAMP;
 pub const BASE_SEPOLIA_HOLOCENE_TIMESTAMP: u64 = OP_SEPOLIA_HOLOCENE_TIMESTAMP;
 /// Isthmus base sepolia hardfork activation timestamp is 1744905600.
 pub const BASE_SEPOLIA_ISTHMUS_TIMESTAMP: u64 = OP_SEPOLIA_ISTHMUS_TIMESTAMP;
-/// Jovian base sepolia hardfork activation timestamp is 1_762_358_401.
+/// Jovian base sepolia hardfork activation timestamp is 1_762_963_201.
 pub const BASE_SEPOLIA_JOVIAN_TIMESTAMP: u64 = OP_SEPOLIA_JOVIAN_TIMESTAMP;

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -175,7 +175,7 @@ impl OpHardfork {
             (Self::Granite, ForkCondition::ZERO_TIMESTAMP),
             (Self::Holocene, ForkCondition::ZERO_TIMESTAMP),
             (Self::Isthmus, ForkCondition::ZERO_TIMESTAMP),
-            (Self::Jovian, ForkCondition::Timestamp(1761840000)),
+            (Self::Jovian, ForkCondition::Timestamp(1762185600)),
         ]
     }
 

--- a/crates/op-hardforks/src/optimism/mainnet.rs
+++ b/crates/op-hardforks/src/optimism/mainnet.rs
@@ -20,5 +20,5 @@ pub const OP_MAINNET_GRANITE_TIMESTAMP: u64 = 1_726_070_401;
 pub const OP_MAINNET_HOLOCENE_TIMESTAMP: u64 = 1_736_445_601;
 /// Isthmus hardfork activation timestamp is 1746806401.
 pub const OP_MAINNET_ISTHMUS_TIMESTAMP: u64 = 1_746_806_401;
-/// Jovian hardfork activation timestamp is 1_763_481_601.
-pub const OP_MAINNET_JOVIAN_TIMESTAMP: u64 = 1_763_481_601;
+/// Jovian hardfork activation timestamp is 1_764_086_401.
+pub const OP_MAINNET_JOVIAN_TIMESTAMP: u64 = 1_764_086_401;

--- a/crates/op-hardforks/src/optimism/sepolia.rs
+++ b/crates/op-hardforks/src/optimism/sepolia.rs
@@ -16,5 +16,5 @@ pub const OP_SEPOLIA_GRANITE_TIMESTAMP: u64 = 1_723_478_400;
 pub const OP_SEPOLIA_HOLOCENE_TIMESTAMP: u64 = 1_732_633_200;
 /// Isthmus sepolia hardfork activation timestamp is 1744905600.
 pub const OP_SEPOLIA_ISTHMUS_TIMESTAMP: u64 = 1_744_905_600;
-/// Jovian sepolia hardfork activation timestamp is 1_762_358_401.
-pub const OP_SEPOLIA_JOVIAN_TIMESTAMP: u64 = 1_762_358_401;
+/// Jovian sepolia hardfork activation timestamp is 1_762_963_201.
+pub const OP_SEPOLIA_JOVIAN_TIMESTAMP: u64 = 1_762_963_201;


### PR DESCRIPTION
## Description

Update Jovian timestamps. Relevant SCR PR: https://github.com/ethereum-optimism/superchain-registry/pull/1130

```
MAINNET

The below chains will activate Jovian on Mainnet at jovian_time = 1764086401 # Tue 25 Nov 2025 16:00:01 UTC (grep -l jovian_time *):

SEPOLIA

The below chains will activate Jovian on Sepolia at jovian_time = 1762963201 # Wed 12 Nov 2025 16:00:01 UTC (grep -l jovian_time *`):


BETANET

The below chains will activate Jovian on devnet at jovian_time = 1762185600 # Mon 3 Nov 2025 16:00:00 UTC
```