### PR TITLE
revert matt/make-enums-non-exhaustive

### DIFF
--- a/crates/hardforks/src/hardfork/macros.rs
+++ b/crates/hardforks/src/hardfork/macros.rs
@@ -5,7 +5,6 @@ macro_rules! hardfork {
     ($(#[$enum_meta:meta])* $enum:ident { $( $(#[$meta:meta])* $variant:ident ),* $(,)? }) => {
         $(#[$enum_meta])*
         #[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
-        #[non_exhaustive]
         pub enum $enum {
             $( $(#[$meta])* $variant ),*
         }

--- a/crates/op-hardforks/src/lib.rs
+++ b/crates/op-hardforks/src/lib.rs
@@ -387,7 +387,6 @@ impl Index<EthereumHardfork> for OpChainHardforks {
             Prague => &self[Isthmus],
             // Not activated for now
             Osaka | Bpo1 | Bpo2 | Bpo3 | Bpo4 | Bpo5 | Amsterdam => &ForkCondition::Never,
-            _ => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
Make handling of forks explicit again.

Reverts: https://github.com/alloy-rs/hardforks/pull/62