### PR TITLE
feat: add osaka activation blocks for mainnet, sepolia, and hoodi

### DIFF
--- a/crates/hardforks/src/ethereum/hoodi.rs
+++ b/crates/hardforks/src/ethereum/hoodi.rs
@@ -2,6 +2,8 @@
 
 /// Prague hoodi hard fork activation block is 60412.
 pub const HOODI_PRAGUE_BLOCK: u64 = 60412;
+/// Osaka hoodi hard fork activation block is 1507304.
+pub const HOODI_OSAKA_BLOCK: u64 = 1_507_304;
 
 /// Prague hoodi hard fork activation timestamp is 1742999832.
 pub const HOODI_PRAGUE_TIMESTAMP: u64 = 1_742_999_832;

--- a/crates/hardforks/src/ethereum/mainnet.rs
+++ b/crates/hardforks/src/ethereum/mainnet.rs
@@ -38,6 +38,8 @@ pub const MAINNET_SHANGHAI_BLOCK: u64 = 17_034_870;
 pub const MAINNET_CANCUN_BLOCK: u64 = 19_426_587;
 /// Prague hard fork activation block is 22431084.
 pub const MAINNET_PRAGUE_BLOCK: u64 = 22_431_084;
+/// Osaka hard fork activation block is 23935694.
+pub const MAINNET_OSAKA_BLOCK: u64 = 23_935_694;
 
 /// Paris hard fork activation terminal total difficulty is 58_750_000_000_000_000_000_000_U256.
 pub const MAINNET_PARIS_TTD: U256 = uint!(58_750_000_000_000_000_000_000_U256);

--- a/crates/hardforks/src/ethereum/sepolia.rs
+++ b/crates/hardforks/src/ethereum/sepolia.rs
@@ -18,6 +18,8 @@ pub const SEPOLIA_SHANGHAI_BLOCK: u64 = 2_990_908;
 pub const SEPOLIA_CANCUN_BLOCK: u64 = 5_187_023;
 /// Prague sepolia hard fork activation block is 7836331.
 pub const SEPOLIA_PRAGUE_BLOCK: u64 = 7_836_331;
+/// Osaka sepolia hard fork activation block is 9408576.
+pub const SEPOLIA_OSAKA_BLOCK: u64 = 9_408_576;
 
 /// Paris sepolia hard fork activation timestamp is 1633267481.
 pub const SEPOLIA_PARIS_TIMESTAMP: u64 = 1_633_267_481;

--- a/crates/hardforks/src/hardfork/ethereum.rs
+++ b/crates/hardforks/src/hardfork/ethereum.rs
@@ -113,6 +113,7 @@ impl EthereumHardfork {
             Self::Shanghai => Some(MAINNET_SHANGHAI_BLOCK),
             Self::Cancun => Some(MAINNET_CANCUN_BLOCK),
             Self::Prague => Some(MAINNET_PRAGUE_BLOCK),
+            Self::Osaka => Some(MAINNET_OSAKA_BLOCK),
             _ => None,
         }
     }
@@ -138,6 +139,7 @@ impl EthereumHardfork {
             Self::Shanghai => Some(SEPOLIA_SHANGHAI_BLOCK),
             Self::Cancun => Some(SEPOLIA_CANCUN_BLOCK),
             Self::Prague => Some(SEPOLIA_PRAGUE_BLOCK),
+            Self::Osaka => Some(SEPOLIA_OSAKA_BLOCK),
             _ => None,
         }
     }
@@ -188,6 +190,7 @@ impl EthereumHardfork {
             | Self::Shanghai
             | Self::Cancun => Some(0),
             Self::Prague => Some(HOODI_PRAGUE_BLOCK),
+            Self::Osaka => Some(HOODI_OSAKA_BLOCK),
             _ => None,
         }
     }
@@ -603,7 +606,8 @@ impl EthereumHardfork {
             _i if num < MAINNET_SHANGHAI_BLOCK => Self::Paris,
             _i if num < MAINNET_CANCUN_BLOCK => Self::Shanghai,
             _i if num < MAINNET_PRAGUE_BLOCK => Self::Cancun,
-            _ => Self::Prague,
+            _i if num < MAINNET_OSAKA_BLOCK => Self::Prague,
+            _ => Self::Osaka,
         }
     }
 


### PR DESCRIPTION
Adds osaka hardfork activation block numbers:
- Mainnet: 23,935,694
- Sepolia: 9,408,576
- Hoodi: 1,507,304

Updates `mainnet_activation_block`, `sepolia_activation_block`, and `hoodi_activation_block` functions to return Osaka block numbers.

Also updates `from_mainnet_block_number` to properly return `Osaka` for blocks >= `MAINNET_OSAKA_BLOCK`.

Closes #89